### PR TITLE
Nuget post build config fixes

### DIFF
--- a/Flurl.Http/Flurl.Http.csproj
+++ b/Flurl.Http/Flurl.Http.csproj
@@ -121,7 +121,7 @@
     <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
   </Target>
   <PropertyGroup>
-    <PostBuildEvent>nuget pack $(ProjectPath) -o $(SolutionDir)\publish -IncludeReferencedProjects -Prop Configuration=Release</PostBuildEvent>
+    <PostBuildEvent>$(SolutionDir).nuget\nuget.exe pack $(ProjectPath) -o $(SolutionDir)publish -IncludeReferencedProjects -Prop Configuration=$(ConfigurationName)</PostBuildEvent>
   </PropertyGroup>
   <Import Project="..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" />
   <Target Name="EnsureBclBuildImported" BeforeTargets="BeforeBuild" Condition="'$(BclBuildImported)' == ''">

--- a/Flurl/Flurl.csproj
+++ b/Flurl/Flurl.csproj
@@ -51,7 +51,7 @@
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
   </PropertyGroup>
   <PropertyGroup>
-    <PostBuildEvent>nuget pack $(ProjectPath) -o $(SolutionDir)\publish -Prop Configuration=Release</PostBuildEvent>
+    <PostBuildEvent>$(SolutionDir).nuget\nuget.exe pack $(ProjectPath) -o $(SolutionDir)\publish -Prop Configuration=$(ConfigurationName)</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
I'm submitting a separate pull request for a couple of Nuget-related changes I made.  When I pulled down this solution, I wasn't able to build it because of a couple of post-build errors for building the Nuget packages for Flurl and Flurl.Http.  This first change I made was to use the $(ConfigurationName) variable for setting the configuration so solution builds for debug as well as release.

Once that was working, the Flurl.Http post build still failed with an error code of 1.  So I ran the build step in a console window and got the following error:

> The 'Microsoft.Bcl 1.1.8' package requires NuGet client version '2.8.1' or above, but the current NuGet version is '2.5.40416.9020'.

I realized that it was not using a Use nuget.exe that's bundled with the project but apparently nuget.exe from a path variable.  When I changed the post build step to point to the nuget.exe from the .nuget folder, it worked.

Hopefully this will help other contributors to be able to pull and build without any issues.
