### PR TITLE
Avoid the use of async/await in the shared library

### DIFF
--- a/Flurl.Http.NET45/Flurl.Http.NET45.csproj
+++ b/Flurl.Http.NET45/Flurl.Http.NET45.csproj
@@ -37,6 +37,9 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Newtonsoft.Json.6.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
+    <Reference Include="Rackspace.Threading">
+      <HintPath>..\packages\Rackspace.Threading.1.0.0\lib\net45\Rackspace.Threading.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Net.Http" />

--- a/Flurl.Http.NET45/packages.config
+++ b/Flurl.Http.NET45/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="6.0.3" targetFramework="net45" />
+  <package id="Rackspace.Threading" version="1.0.0" targetFramework="net45" />
 </packages>

--- a/Flurl.Http.PCL/Flurl.Http.PCL.csproj
+++ b/Flurl.Http.PCL/Flurl.Http.PCL.csproj
@@ -59,6 +59,9 @@
     <Reference Include="PCLStorage.Abstractions">
       <HintPath>..\packages\PCLStorage.0.9.6\lib\portable-net45+sl5+wp8+wpa81+win8+monoandroid+monotouch\PCLStorage.Abstractions.dll</HintPath>
     </Reference>
+    <Reference Include="Rackspace.Threading">
+      <HintPath>..\packages\Rackspace.Threading.1.0.0\lib\portable-net4+sl5+netcore45+wp8+MonoAndroid1+MonoTouch1\Rackspace.Threading.dll</HintPath>
+    </Reference>
     <Reference Include="System.IO">
       <HintPath>..\packages\Microsoft.Bcl.1.1.9\lib\portable-net40+sl5+win8+wp8+wpa81\System.IO.dll</HintPath>
     </Reference>

--- a/Flurl.Http.PCL/packages.config
+++ b/Flurl.Http.PCL/packages.config
@@ -6,4 +6,5 @@
   <package id="Microsoft.Net.Http" version="2.2.22" targetFramework="portable-net40+sl50+win+wp80" />
   <package id="Newtonsoft.Json" version="6.0.3" targetFramework="portable-win+net45+sl50+wp80" requireReinstallation="True" />
   <package id="PCLStorage" version="0.9.6" targetFramework="portable-net45+sl50+win+wp80" />
+  <package id="Rackspace.Threading" version="1.0.0" targetFramework="portable-net4+sl5+netcore45+wp8+MonoAndroid1+MonoTouch1" />
 </packages>


### PR DESCRIPTION
This is a pull request to think about, and not necessarily merge.

What I've done here is remove the use of `async`/`await` in the shared library without changing any of the original behavior (except in one case, noted below). This provides you with two advantages:

1. Providing a full-featured library targeting .NET 4.0 is straightforward. The threading library provides the necessary `StreamExtensions`, and there is no need to depend on the [Microsoft Async](https://www.nuget.org/packages/Microsoft.Bcl.Async/) package.
2. Providing a .NET 3.5 version becomes possible, if you wish, using the [TaskParallelLibrary](https://www.nuget.org/packages/TaskParallelLibrary/) package and my back-port of [System.Net.Http to .NET 3.5](https://github.com/sharwell/openstack.net/tree/checkpoint/HttpClientAlt/src/System.Net.Http), which will soon be available as a separate NuGet package.