### PR TITLE
Crash when creating an Url object with Query String containing only the key part

### DIFF
--- a/Flurl/QueryParamCollection.cs
+++ b/Flurl/QueryParamCollection.cs
@@ -29,7 +29,7 @@ namespace Flurl
 			foreach (var kv in queryString.Split('&')) {
 				var pair = kv.Split('=');
 				var key = pair[0];
-				var value = pair.Length > 0 ? pair[1] : "";
+				var value = pair.Length >= 2 ? pair[1] : "";
 				result.Add(key, Uri.UnescapeDataString(value));
 			}
 

--- a/Test/Flurl.Test.Shared/UrlBuilderTests.cs
+++ b/Test/Flurl.Test.Shared/UrlBuilderTests.cs
@@ -26,6 +26,15 @@ namespace Flurl.Test
 		}
 
 		[Test]
+		public void Should_Accept_QueryString_Without_ValuePair()
+		{
+			var url = new Url("http://example.com?123456");
+			Assert.AreEqual("http://example.com", url.Path);
+			Assert.AreEqual(1, url.QueryParams.Keys.Count);
+			Assert.AreEqual(string.Empty, url.QueryParams["123456"]);
+		}
+
+		[Test]
 		public void Path_returns_everything_but_querystring() {
 			var path = new Url("http://www.mysite.com/more?x=1&y=2").Path;
 			Assert.AreEqual("http://www.mysite.com/more", path);


### PR DESCRIPTION
If the query string does not contain a value pair (eg, `key=value`, but only `key`), the code crashes. This commit fixes that. 
