### PR TITLE
Fixes incorrect Url.ToString() when no value for the key

### DIFF
--- a/Flurl/QueryParamCollection.cs
+++ b/Flurl/QueryParamCollection.cs
@@ -45,7 +45,10 @@ namespace Flurl
 		/// </summary>
 		/// <returns></returns>
 		public override string ToString() {
-			return string.Join("&", _orderedKeys.Select(k => k + "=" + Uri.EscapeDataString(this[k].ToString())).ToArray());
+			return string.Join("&", _orderedKeys.Select(k => {
+				var value = Uri.EscapeDataString(this[k].ToString());
+				return string.IsNullOrEmpty(value) ? k : (k + "=" + value);
+			}).ToArray());
 		}
 
 		#region IDictionary<string, object> members

--- a/Test/Flurl.Test.Shared/UrlBuilderTests.cs
+++ b/Test/Flurl.Test.Shared/UrlBuilderTests.cs
@@ -26,6 +26,13 @@ namespace Flurl.Test
 		}
 
 		[Test]
+		public void Should_Not_Add_Equals_Without_Value()
+		{
+			var url = new Url("http://example.com?123456");
+			Assert.AreEqual("http://example.com?123456", url.ToString());
+		}
+
+		[Test]
 		public void Should_Accept_QueryString_Without_ValuePair()
 		{
 			var url = new Url("http://example.com?123456");


### PR DESCRIPTION
This is related to https://github.com/tmenier/Flurl/pull/11, and in this case a call to `new Url('http://example.com?123456').ToString()` generated `http://example.com?123456=` as output. This commit fixes that so the equals sign is not added if there isn't any value for the given key. 