### PR TITLE
Handle Enumerables of KeyValuePairs gracefully

### DIFF
--- a/Flurl/Util/CommonExtensions.cs
+++ b/Flurl/Util/CommonExtensions.cs
@@ -20,6 +20,10 @@ namespace Flurl.Util
 				foreach (DictionaryEntry kv in (IDictionary)obj)
 					yield return new KeyValuePair<string, string>(kv.Key.ToString(), kv.Value.ToString());
 			}
+			else if (obj is IEnumerable<KeyValuePair<object, object>>) {
+				foreach (var kv in (IEnumerable<KeyValuePair<object, object>>)obj)
+					yield return new KeyValuePair<string, string>(kv.Key.ToString(), kv.Value.ToString());
+			}
 			else {
 				foreach (var prop in obj.GetType().GetProperties()) {
 					yield return new KeyValuePair<string, string>(prop.Name, prop.GetValue(obj, null).ToString());


### PR DESCRIPTION
When you pass an IEnumerable<KeyValuePair<object, object>> to i.e. string.SetQueryParameters() you get unexpected results as the ToKeyValuePairs takes the properties of the IEnumerable instead of the KeyValuePairs inside it. Extensions such as resharper will in some instances notify you that you can use IEnumerable<KeyValuePair<object, object>> over IDictionary<object, object>.

This pull request addresses those instances.