### PR TITLE
use InvariantCulture for query params formating

### DIFF
--- a/Flurl/Url.cs
+++ b/Flurl/Url.cs
@@ -103,7 +103,7 @@ namespace Flurl
 		/// <param name="value">value of query string parameter</param>
 		/// <returns>The Url obect with the query string parameter added</returns>
 		public Url SetQueryParam(string name, object value) {
-			QueryParams[name] = (value == null) ? null : value.ToString();
+			QueryParams[name] = (value == null) ? null : value.ToInvariantString();
 			return this;
 		}
 

--- a/Flurl/Util/CommonExtensions.cs
+++ b/Flurl/Util/CommonExtensions.cs
@@ -18,13 +18,23 @@ namespace Flurl.Util
 
 			if (obj is IDictionary) {
 				foreach (DictionaryEntry kv in (IDictionary)obj)
-					yield return new KeyValuePair<string, string>(kv.Key.ToString(), kv.Value.ToString());
+					yield return new KeyValuePair<string, string>(kv.Key.ToInvariantString(), kv.Value.ToInvariantString());
 			}
 			else {
 				foreach (var prop in obj.GetType().GetProperties()) {
-					yield return new KeyValuePair<string, string>(prop.Name, prop.GetValue(obj, null).ToString());
+					yield return new KeyValuePair<string, string>(prop.Name, prop.GetValue(obj, null).ToInvariantString());
 				}
 			}
+		}
+
+		/// <summary>
+		/// Converts an object to string using invariant culture format provider.
+		/// </summary>
+		/// <param name="obj"></param>
+		/// <returns></returns>
+		internal static string ToInvariantString(this object obj)
+		{
+			return String.Format(System.Globalization.CultureInfo.InvariantCulture, "{0}", obj);
 		}
 	}
 }

--- a/Test/Flurl.Test.Shared/UrlBuilderTests.cs
+++ b/Test/Flurl.Test.Shared/UrlBuilderTests.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Reflection;
+using System.Threading;
 using NUnit.Framework;
 
 namespace Flurl.Test
@@ -111,6 +113,22 @@ namespace Flurl.Test
 			// let's challenge it a little with non-string keys
 			var url = "http://www.mysite.com".SetQueryParams(new Dictionary<int, string> {{1, "x"}, {2, "y"}});
 			Assert.AreEqual("http://www.mysite.com?1=x&2=y", url.ToString());
+		}
+
+		[Test]
+		public void SetQueryParam_uses_invariant_culture()
+		{
+			Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfo("es-ES");
+			var url = "http://www.mysite.com".SetQueryParam("x", 1.1);
+			Assert.AreEqual("http://www.mysite.com?x=1.1", url.ToString());
+		}
+
+		[Test]
+		public void SetQueryParams_uses_invariant_culture()
+		{
+			Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfo("es-ES");
+			var url = "http://www.mysite.com".SetQueryParams(new { x = 1.1 });
+			Assert.AreEqual("http://www.mysite.com?x=1.1", url.ToString());
 		}
 
 		[Test]


### PR DESCRIPTION
Query string formatting should not depend on environment culture settings