### PR TITLE
Added support for (non-global) CookieContianer 

### DIFF
--- a/Flurl.Http.NET45/Flurl.Http.NET45.csproj
+++ b/Flurl.Http.NET45/Flurl.Http.NET45.csproj
@@ -39,6 +39,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Net" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/Flurl.Http.Shared/Configuration/DefaultHttpClientFactory.cs
+++ b/Flurl.Http.Shared/Configuration/DefaultHttpClientFactory.cs
@@ -1,4 +1,5 @@
-﻿using System.Net.Http;
+﻿using System.Net;
+using System.Net.Http;
 
 namespace Flurl.Http.Configuration
 {
@@ -10,8 +11,14 @@ namespace Flurl.Http.Configuration
 	/// </summary>
 	public class DefaultHttpClientFactory : IHttpClientFactory
 	{
-		public virtual HttpClient CreateClient(Url url) {
-			return new HttpClient(new FlurlMessageHandler()) {
+        public virtual HttpClient CreateClient(Url url) {
+
+            FlurlMessageHandler flurlHandler;
+            if (url.CookieContainer != null)
+                flurlHandler = new FlurlMessageHandler(new HttpClientHandler() { CookieContainer = url.CookieContainer });
+            else
+                flurlHandler = new FlurlMessageHandler();
+            return new HttpClient(flurlHandler) {
 				Timeout = FlurlHttp.Configuration.DefaultTimeout
 			};
 		}

--- a/Flurl.Http.Shared/FlurlClient.cs
+++ b/Flurl.Http.Shared/FlurlClient.cs
@@ -1,4 +1,5 @@
-﻿using System.Net.Http;
+﻿using System.Net;
+using System.Net.Http;
 
 namespace Flurl.Http
 {
@@ -7,7 +8,7 @@ namespace Flurl.Http
 	/// </summary>
 	public class FlurlClient
 	{
-		public FlurlClient(string url) : this(new Url(url)) { }
+        public FlurlClient(string url, CookieContainer cookieContainer = null) : this(new Url(url, cookieContainer)) { }
 
 		public FlurlClient(Url url) {
 			this.Url = url;
@@ -27,7 +28,7 @@ namespace Flurl.Http
 		public HttpClient HttpClient {
 			get {
 				if (_httpClient == null)
-					_httpClient = FlurlHttp.Configuration.HttpClientFactory.CreateClient(Url);
+                    _httpClient = FlurlHttp.Configuration.HttpClientFactory.CreateClient(Url);
 				return _httpClient;
 			}
 		}

--- a/Flurl/Url.cs
+++ b/Flurl/Url.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using Flurl.Util;
+using System.Net;
 
 namespace Flurl
 {
@@ -19,17 +20,22 @@ namespace Flurl
 		/// </summary>
 		public IDictionary<string, object> QueryParams { get; private set; }
 
+        /// <summary>
+        /// Cookies container for the FlurlClient
+        /// </summary>
+        public CookieContainer CookieContainer { get; private set; }
 		/// <summary>
 		/// Constructs a Url object from a string.
 		/// </summary>
 		/// <param name="baseUrl">The URL to use as a starting point (required)</param>
-		public Url(string baseUrl) {
+		public Url(string baseUrl, CookieContainer cookieContainer = null) {
 			if (baseUrl == null)
 				throw new ArgumentNullException("baseUrl");
 
 			var parts = baseUrl.Split('?');
 			Path = parts[0];
 			QueryParams = QueryParamCollection.Parse(parts.Length > 1 ? parts[1] : "");
+            CookieContainer = cookieContainer;
 		}
 
 		/// <summary>
@@ -95,6 +101,11 @@ namespace Flurl
 
 			return this;
 		}
+
+        public Url WithCookieContainer(CookieContainer cookieContainer) {
+            CookieContainer = cookieContainer;
+            return this;
+        }
 
 		/// <summary>
 		/// Adds a parameter to the query string, overwriting the value if name exists.

--- a/Test/Flurl.Test.NET45/Flurl.Test.NET45.csproj
+++ b/Test/Flurl.Test.NET45/Flurl.Test.NET45.csproj
@@ -37,6 +37,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Net" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/Test/Flurl.Test.PCL/Flurl.Test.PCL.csproj
+++ b/Test/Flurl.Test.PCL/Flurl.Test.PCL.csproj
@@ -44,6 +44,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Net" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />


### PR DESCRIPTION
Added support for a CookieContainer. A number of REST api's use OAuth or other form of cookie authentication so cookie support is essential. Also, the CookieContainer has to be associated with the Url instance and not the global configuration. This is because the client app may have multiple clients accessing the remote resources and you cannot have one global cookie container.

Kept things simple:

var url = new Url(urlString).WithCookieContainer(cookieContainer)....