### PR TITLE
Allow customization of JSON.Net serialization settings.

### DIFF
--- a/Flurl.Http.Shared/Configuration/FlurlHttpConfigurationOptions.cs
+++ b/Flurl.Http.Shared/Configuration/FlurlHttpConfigurationOptions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Net.Http;
 using System.Threading.Tasks;
+using Newtonsoft.Json;
 
 namespace Flurl.Http.Configuration
 {
@@ -32,6 +33,13 @@ namespace Flurl.Http.Configuration
 		/// otherwise functionality such as callbacks and most testing features will be lost.
 		/// </summary>
 		public IHttpClientFactory HttpClientFactory { get; set; }
+
+		/// <summary>
+		/// Allows global customization of the JSON.Net serializer settings. These allow you to add custom
+		/// JsonConverters and alter other behaviors like date formatting and null handling. For more information,
+		/// see: http://www.newtonsoft.com/json/help/html/SerializationSettings.htm
+		/// </summary>
+		public JsonSerializerSettings JsonSerializerSettings { get; set; }
 
 		/// <summary>
 		/// Gets or sets a callback that is called immediately before every HTTP request is sent.
@@ -72,6 +80,7 @@ namespace Flurl.Http.Configuration
 			DefaultTimeout = new HttpClient().Timeout;
 			AllowedHttpStatusRange = null;
 			HttpClientFactory = new DefaultHttpClientFactory();
+			JsonSerializerSettings = new JsonSerializerSettings();
 			BeforeCall = null;
 			BeforeCallAsync = null;
 			AfterCall = null;

--- a/Flurl.Http.Shared/Content/CapturedJsonContent.cs
+++ b/Flurl.Http.Shared/Content/CapturedJsonContent.cs
@@ -9,6 +9,7 @@ namespace Flurl.Http.Content
 	/// </summary>
 	public class CapturedJsonContent : CapturedStringContent
 	{
-		public CapturedJsonContent(object data) : base(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json") { }
+		public CapturedJsonContent(object data)
+			: base(JsonConvert.SerializeObject(data, FlurlHttp.Configuration.JsonSerializerSettings), Encoding.UTF8, "application/json") { }
 	}
 }

--- a/Flurl.Http.Shared/FlurlHttpException.cs
+++ b/Flurl.Http.Shared/FlurlHttpException.cs
@@ -56,7 +56,7 @@ namespace Flurl.Http
 			return
 				(Call == null) ? default(T) :
 				(Call.ErrorResponseBody == null) ? default(T) :
-				JsonConvert.DeserializeObject<T>(Call.ErrorResponseBody);
+				JsonConvert.DeserializeObject<T>(Call.ErrorResponseBody, FlurlHttp.Configuration.JsonSerializerSettings);
 		}
 
 		/// <summary>

--- a/Flurl.Http.Shared/Util/JsonHelper.cs
+++ b/Flurl.Http.Shared/Util/JsonHelper.cs
@@ -9,7 +9,7 @@ namespace Flurl.Http
 			// http://james.newtonking.com/json/help/index.html?topic=html/Performance.htm
 			using (var sr = new StreamReader(stream))
 			using (var jr = new JsonTextReader(sr)) {
-				return new JsonSerializer().Deserialize<T>(jr);
+				return JsonSerializer.Create(FlurlHttp.Configuration.JsonSerializerSettings).Deserialize<T>(jr);
 			}
 		}
 	}


### PR DESCRIPTION
I'm writing a client library for Slack and need to customize some of the JSON.Net serialization behaviors (such as date handling and property mapping). There didn't seem to be an offical way to do that, so I made what I think is a minimally invasive change to support it.

Happy to rework it as you see fit as long as you're willing to merge it, so criticism is welcome. :smile: 