### PR TITLE
Add AllowHttpStatus(HttpStatusCode)

### DIFF
--- a/Flurl.Http.Shared/ClientConfigExtensions.cs
+++ b/Flurl.Http.Shared/ClientConfigExtensions.cs
@@ -263,6 +263,15 @@ namespace Flurl.Http
 			return client;
 		}
 
+	    /// <summary>
+	    /// Adds an <see cref="HttpStatusCode"/> which (in addtion to 2xx) will NOT result in a FlurlHttpException being thrown.
+	    /// </summary>
+	    /// <param name="statusCode">Examples: HttpStatusCode.NotFound</param>
+	    /// <returns>The modified FlurlClient.</returns>
+	    public static FlurlClient AllowHttpStatus(this FlurlClient client, HttpStatusCode statusCode) {
+            return AllowHttpStatus(client, ((int)statusCode).ToString());
+        }
+
 		/// <summary>
 		/// Creates a FlurlClient from the URL and adds a pattern representing an HTTP status code or range of codes which (in addtion to 2xx) will NOT result in a FlurlHttpException being thrown.
 		/// </summary>
@@ -280,6 +289,15 @@ namespace Flurl.Http
 		public static FlurlClient AllowHttpStatus(this string url, string pattern) {
 			return new FlurlClient(url, true).AllowHttpStatus(pattern);
 		}
+
+        /// <summary>
+        /// Adds an <see cref="HttpStatusCode"/> which (in addtion to 2xx) will NOT result in a FlurlHttpException being thrown.
+        /// </summary>
+        /// <param name="statusCode">Examples: HttpStatusCode.NotFound</param>
+        /// <returns>The new FlurlClient.</returns>
+        public static FlurlClient AllowHttpStatus(this string url, HttpStatusCode statusCode) {
+            return new FlurlClient(url, true).AllowHttpStatus(statusCode);
+        }
 
 		/// <summary>
 		/// Prevents a FlurlHttpException from being thrown on any completed response, regardless of the HTTP status code.

--- a/Test/Flurl.Test.Shared/Http/ClientConfigTests.cs
+++ b/Test/Flurl.Test.Shared/Http/ClientConfigTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Threading.Tasks;
 using Flurl.Http;
 using Flurl.Http.Testing;
@@ -114,5 +115,17 @@ namespace Flurl.Test.Http
 				await client.GetAsync();
 			}
 		}
+
+        [Test]
+        public async Task can_allow_specific_http_status()
+        {
+            using (var test = new HttpTest())
+            {
+                test.RespondWith(404, "Nothing to see here");
+                // allow 404
+                var client = "http://www.api.com".AllowHttpStatus(HttpStatusCode.NotFound);
+                await client.DeleteAsync();
+            }
+        }
 	}
 }


### PR DESCRIPTION
It would be nice to directly use the HttpStatusCode enum when a pattern is not needed.

```csharp
"http://www.api.com/foo/1"
    .AllowHttpStatus(HttpStatusCode.NotFound)
    .DeleteAsync()
```