### PR TITLE
Include Error Body in InnerException of FlurlHttpException

### DIFF
--- a/Flurl.Http.Shared/FlurlHttpException.cs
+++ b/Flurl.Http.Shared/FlurlHttpException.cs
@@ -16,13 +16,18 @@ namespace Flurl.Http
 		/// </summary>
 		public HttpCall Call { get; private set; }
 
-		public FlurlHttpException(HttpCall call, string message, Exception inner) : base(message, inner) {
+		public FlurlHttpException(HttpCall call, string message, Exception inner) : base(message, inner ?? BuildInnerException(call)) {
 			this.Call = call;
 		}
 
 		public FlurlHttpException(HttpCall call, Exception inner) : this(call, BuildMessage(call, inner), inner) { }
 
-		public FlurlHttpException(HttpCall call) : this(call, BuildMessage(call, null), null) { }
+		public FlurlHttpException(HttpCall call) : this(call, BuildMessage(call, null), BuildInnerException(call)) { }
+
+		private static Exception BuildInnerException(HttpCall call)
+		{
+			return new Exception(call.ErrorResponseBody);
+		}
 
 		private static string BuildMessage(HttpCall call, Exception inner) {
 			if (call.Response != null && !call.Succeeded) {


### PR DESCRIPTION
When an inner exception is not provided, include the response body in the FlurlHttpException's inner exception. This allows most application's default exception handling to have access to the error details.

For example, unit test frameworks and loggers will capture both the root and any inner exceptions but won't capture the HttpCall (and error body). This enables tests to capture/display the error body without
having to wrap every test in a try/catch.