### PR TITLE
new api to assert request body as object

### DIFF
--- a/Flurl.Http.Shared/Testing/HttpCallAssertion.cs
+++ b/Flurl.Http.Shared/Testing/HttpCallAssertion.cs
@@ -57,15 +57,15 @@ namespace Flurl.Http.Testing
 			return With(c => MatchesPattern(c.RequestBody, bodyPattern));
 		}
 
-        /// <summary>
-        /// Asserts whether calls were made containing given request body.
-        /// </summary>
-        /// <param name="body"></param>
-        /// <returns></returns>
-	    public HttpCallAssertion WithRequestBodyJson(object body){
-            var serializedBody = FlurlHttp.GlobalSettings.JsonSerializer.Serialize(body);
-            return With(c => MatchesPattern(c.RequestBody, serializedBody));
-	    }
+		/// <summary>
+		/// Asserts whether calls were made containing given request body.
+		/// </summary>
+		/// <param name="body"></param>
+		/// <returns></returns>
+		public HttpCallAssertion WithRequestBodyJson(object body) {
+			var serializedBody = FlurlHttp.GlobalSettings.JsonSerializer.Serialize(body);
+			return With(c => MatchesPattern(c.RequestBody, serializedBody));
+		}
 
 		/// <summary>
 		/// Asserts whether calls were made with given HTTP verb.

--- a/Flurl.Http.Shared/Testing/HttpCallAssertion.cs
+++ b/Flurl.Http.Shared/Testing/HttpCallAssertion.cs
@@ -49,13 +49,23 @@ namespace Flurl.Http.Testing
 		}
 
 		/// <summary>
-		/// Asserts wheter calls were made containing given request body or request body pattern.
+		/// Asserts whether calls were made containing given request body or request body pattern.
 		/// </summary>
 		/// <param name="bodyPattern">Can contain * wildcard.</param>
 		/// <returns></returns>
 		public HttpCallAssertion WithRequestBody(string bodyPattern) {
 			return With(c => MatchesPattern(c.RequestBody, bodyPattern));
 		}
+
+        /// <summary>
+        /// Asserts whether calls were made containing given request body.
+        /// </summary>
+        /// <param name="body"></param>
+        /// <returns></returns>
+	    public HttpCallAssertion WithRequestBodyJson(object body){
+            var serializedBody = FlurlHttp.GlobalSettings.JsonSerializer.Serialize(body);
+            return With(c => MatchesPattern(c.RequestBody, serializedBody));
+	    }
 
 		/// <summary>
 		/// Asserts whether calls were made with given HTTP verb.

--- a/Test/Flurl.Test.Shared/Http/PostTests.cs
+++ b/Test/Flurl.Test.Shared/Http/PostTests.cs
@@ -18,17 +18,17 @@ namespace Flurl.Test.Http
 				.Times(1);
 		}
 
-	    [Test]
-	    public async Task can_post_object_as_json(){
-	        var expectedEndpoint = "http://some-api.com";
-	        var expectedBody = new {a = 1, b = 2};
-	        await expectedEndpoint.PostJsonAsync(expectedBody);
-            HttpTest.ShouldHaveCalled(expectedEndpoint)
-                .WithVerb(HttpMethod.Post)
-                .WithContentType("application/json")
-                .WithRequestBodyJson(expectedBody)
-                .Times(1);
-	    }
+		[Test]
+		public async Task can_post_object_as_json() {
+			var expectedEndpoint = "http://some-api.com";
+			var expectedBody = new {a = 1, b = 2};
+			await expectedEndpoint.PostJsonAsync(expectedBody);
+			HttpTest.ShouldHaveCalled(expectedEndpoint)
+				.WithVerb(HttpMethod.Post)
+				.WithContentType("application/json")
+				.WithRequestBodyJson(expectedBody)
+				.Times(1);
+		}
 
 		[Test]
 		public async Task can_post_url_encoded() {

--- a/Test/Flurl.Test.Shared/Http/PostTests.cs
+++ b/Test/Flurl.Test.Shared/Http/PostTests.cs
@@ -18,6 +18,18 @@ namespace Flurl.Test.Http
 				.Times(1);
 		}
 
+	    [Test]
+	    public async Task can_post_object_as_json(){
+	        var expectedEndpoint = "http://some-api.com";
+	        var expectedBody = new {a = 1, b = 2};
+	        await expectedEndpoint.PostJsonAsync(expectedBody);
+            HttpTest.ShouldHaveCalled(expectedEndpoint)
+                .WithVerb(HttpMethod.Post)
+                .WithContentType("application/json")
+                .WithRequestBodyJson(expectedBody)
+                .Times(1);
+	    }
+
 		[Test]
 		public async Task can_post_url_encoded() {
 			await "http://some-api.com".PostUrlEncodedAsync(new { a = 1, b = 2, c = "hi there" });


### PR DESCRIPTION
when asserting complex request body structures, asserting against a string can become a little cumbersome.  adding an extra api that serializes an object and compares the result to the captured body, as what would have been created by PostJson