### PR TITLE
simple encoding fix

### DIFF
--- a/Flurl.Http.Shared/Configuration/FlurlMessageHandler.cs
+++ b/Flurl.Http.Shared/Configuration/FlurlMessageHandler.cs
@@ -36,7 +36,11 @@ namespace Flurl.Http.Configuration
 
 			if (call.Response != null && !call.Succeeded) {
 				if (call.Response.Content != null)
-					call.ErrorResponseBody = await call.Response.Content.ReadAsStringAsync().ConfigureAwait(false);
+					call.ErrorResponseBody = await call.Response
+						.StripCharsetQuotes()
+						.Content
+						.ReadAsStringAsync()
+						.ConfigureAwait(false);
 
 				call.Exception = new FlurlHttpException(call, null);
 			}

--- a/Flurl.Http.Shared/FlurlClient.cs
+++ b/Flurl.Http.Shared/FlurlClient.cs
@@ -87,12 +87,7 @@ namespace Flurl.Http
 			try {
 				var request = new HttpRequestMessage(verb, this.Url) { Content = content };
 				HttpCall.Set(request, this.Settings);
-				var response = await HttpClient.SendAsync(request, completionOption, cancellationToken ?? CancellationToken.None).ConfigureAwait(false);
-				if (response?.Content?.Headers?.ContentType?.CharSet != null)
-				{
-					response.Content.Headers.ContentType.CharSet = response.Content.Headers.ContentType.CharSet.Replace("\"", string.Empty);
-				}
-				return response;
+				return await HttpClient.SendAsync(request, completionOption, cancellationToken ?? CancellationToken.None).ConfigureAwait(false);
 			}
 			finally {
 				if (AutoDispose) Dispose();

--- a/Flurl.Http.Shared/FlurlClient.cs
+++ b/Flurl.Http.Shared/FlurlClient.cs
@@ -87,7 +87,12 @@ namespace Flurl.Http
 			try {
 				var request = new HttpRequestMessage(verb, this.Url) { Content = content };
 				HttpCall.Set(request, this.Settings);
-				return await HttpClient.SendAsync(request, completionOption, cancellationToken ?? CancellationToken.None).ConfigureAwait(false);
+				var response = await HttpClient.SendAsync(request, completionOption, cancellationToken ?? CancellationToken.None).ConfigureAwait(false);
+				if (response?.Content?.Headers?.ContentType?.CharSet != null)
+				{
+					response.Content.Headers.ContentType.CharSet = response.Content.Headers.ContentType.CharSet.Replace("\"", string.Empty);
+				}
+				return response;
 			}
 			finally {
 				if (AutoDispose) Dispose();

--- a/Flurl.Http.Shared/HttpResponseMessageExtensions.cs
+++ b/Flurl.Http.Shared/HttpResponseMessageExtensions.cs
@@ -55,8 +55,12 @@ namespace Flurl.Http
 		/// </summary>
 		/// <returns>A Task whose result is the response body as a string.</returns>
 		/// <example>s = await url.PostAsync(data).ReceiveString()</example>
-		public static async Task<string> ReceiveString(this Task<HttpResponseMessage> response) {
-			return await (await response.ConfigureAwait(false)).Content.ReadAsStringAsync().ConfigureAwait(false);
+		public static async Task<string> ReceiveString(this Task<HttpResponseMessage> response)
+		{
+			return await (await response.ConfigureAwait(false))
+				.StripCharsetQuotes()
+				.Content.ReadAsStringAsync()
+				.ConfigureAwait(false);
 		}
 
 		/// <summary>
@@ -75,6 +79,15 @@ namespace Flurl.Http
 		/// <example>bytes = await url.PostAsync(data).ReceiveBytes()</example>
 		public static async Task<byte[]> ReceiveBytes(this Task<HttpResponseMessage> response) {
 			return await (await response.ConfigureAwait(false)).Content.ReadAsByteArrayAsync().ConfigureAwait(false);
+		}
+
+		public static HttpResponseMessage StripCharsetQuotes(this HttpResponseMessage response)
+		{
+			if (response?.Content?.Headers?.ContentType?.CharSet != null)
+			{
+				response.Content.Headers.ContentType.CharSet = response.Content.Headers.ContentType.CharSet.Replace("\"", string.Empty);
+			}
+			return response;
 		}
 	}
 }

--- a/Test/Flurl.Test.Shared/Flurl.Test.Shared.projitems
+++ b/Test/Flurl.Test.Shared/Flurl.Test.Shared.projitems
@@ -10,6 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)CommonExtensionsTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)HttpResponseMessageExtensionsTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Http\ClientConfigTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Http\ClientLifetimeTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Http\HttpStatusRangeParserTests.cs" />

--- a/Test/Flurl.Test.Shared/HttpResponseMessageExtensionsTests.cs
+++ b/Test/Flurl.Test.Shared/HttpResponseMessageExtensionsTests.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Flurl.Http;
+using NUnit.Framework;
+
+namespace Flurl.Test
+{
+	[TestFixture]
+	public class HttpResponseMessageExtensionsTests
+	{
+		[Test]
+		public void StripCharsetQuotes__Given_Response__When_ContentTypeCharsetHasQuotes__Then_RemoveQuotes()
+		{
+			var response = new HttpResponseMessage
+			{
+				Content = new StringContent("Doesn't matter")
+				{
+					Headers =
+					{
+						ContentType =
+						{
+							MediaType = "text/javascript",
+							CharSet = "\"UTF-8\""
+						}
+					}
+				}
+			};
+
+			var result = response.StripCharsetQuotes();
+
+			Assert.AreEqual("UTF-8", result.Content.Headers.ContentType.CharSet);
+		}
+
+		[Test]
+		public async Task ReceiveString__Given_ResponseTask__When_ContentTypeCharsetNonQuoted__Then_GetContentString()
+		{
+			var expectedContent = Guid.NewGuid().ToString();
+
+			var response = new HttpResponseMessage
+			{
+				Content = new StringContent(expectedContent)
+				{
+					Headers =
+					{
+						ContentType =
+						{
+							MediaType = "text/javascript",
+							CharSet = "UTF-8"
+						}
+					}
+				}
+			};
+
+			var subject = Task.FromResult(response);
+			var result = await subject.ReceiveString();
+
+			Assert.AreEqual(expectedContent, result);
+		}
+
+		[Test]
+		public async Task ReceiveString__Given_ResponseTask__When_ContentTypeCharsetQuoted__Then_GetContentString()
+		{
+			var expectedContent = Guid.NewGuid().ToString();
+
+			var response = new HttpResponseMessage
+			{
+				Content = new StringContent(expectedContent)
+				{
+					Headers =
+					{
+						ContentType =
+						{
+							MediaType = "text/javascript",
+							CharSet = "\"UTF-8\""
+						}
+					}
+				}
+			};
+
+			var subject = Task.FromResult(response);
+			var result = await subject.ReceiveString();
+
+			Assert.AreEqual(expectedContent, result);
+		}
+	}
+}


### PR DESCRIPTION
Going to start out by saying I don't think this PR in it's current state is the solution, but more the start of a conversation around a problem.

Here's the problem:

I'm using Flurl.Http to hit a web api that's returning responses with

```Content-Type: text/javascript; charset="UTF-8"```

Notice the charset value surrounded with quotes, which is legal according to this section of the [W3C spec](http://tools.ietf.org/html/rfc7231#section-3.1.1.5).  However, HttpClient is choking on the charset value because it is surrounded with quotes.  ```HttpContent.ReadAsStringAsync()``` uses the Content-Type header's charset value (if present) to determine the encoding to use, but it does not guard itself against the charset value being quoted and throws an exception.  Here's a simple [fiddle](https://dotnetfiddle.net/bNxJAS) of this in action.

I realize this isn't a problem with Flurl.  It is actually a problem with ```HttpContent.ReadAsStringAsync()``` which Flurl uses quite a bit.  Unfortunately, I can't simply submit a PR to the team that maintains ```System.Net.Http```

If HttpClient isn't going to to properly handle different valid charset schemes, I propose we handle it - do you agree?  A few solutions to this:

1. put in the quick fix from this changeset
2. add an extension method on ```Task<HttpResponseMessage>``` that does this work, and potentially handle other gotchas like this
3. add a callback hook like those provided in ```FlurlHttp.Configure``` to give the implementer (like me) access to the ```HttpResponseMessage``` after ```SendAsync``` but before things like ```HttpResponseMessageExtension.ReceiveString``` to allow for "data massaging" like this

I'm leaning towards option 2 as an aggregate extension method like ```ProcessResponse``` that delegates to specific extensions like ```StripCharsetQuotes``` as well as whatever other gotchas come up in the future.

Please let me know your thoughts on the subject and if you like any of options 1-3 or even a 4th option I didn't think of.  I'd be happy to help implement a more robust solution to this problem through this PR depending on what you think fits best for the project.

Thanks!