### PR TITLE
URL fragment support

### DIFF
--- a/Flurl/Url.cs
+++ b/Flurl/Url.cs
@@ -20,26 +20,26 @@ namespace Flurl
 		/// </summary>
 		public QueryParamCollection QueryParams { get; private set; }
 
-        /// <summary>
-        /// The fragment part of the url (after the #, RFC 3986)
-        /// </summary>
-        public string Fragment { get; private set; }
+		/// <summary>
+		/// The fragment part of the url (after the #, RFC 3986)
+		/// </summary>
+		public string Fragment { get; private set; }
 
-        const string URL_SLICE_REGEXP = @"^([^?#\n]*)([^#\n]*)(.*)$";
+		const string URL_SLICE_REGEXP = @"^([^?#\n]*)([^#\n]*)(.*)$";
 
-        /// <summary>
-        /// Constructs a Url object from a string.
-        /// </summary>
-        /// <param name="baseUrl">The URL to use as a starting point (required)</param>
-        public Url(string baseUrl) {
-			if (baseUrl == null)
+		/// <summary>
+		/// Constructs a Url object from a string.
+		/// </summary>
+		/// <param name="baseUrl">The URL to use as a starting point (required)</param>
+		public Url(string baseUrl) {
+			if(baseUrl == null)
 				throw new ArgumentNullException("baseUrl");
 
-            var urlParts = Regex.Match(baseUrl, URL_SLICE_REGEXP, RegexOptions.IgnoreCase | RegexOptions.Singleline);
-            Path = urlParts.Groups[1].Value;
-            QueryParams = QueryParamCollection.Parse(urlParts.Groups[2].Value);
-            Fragment = urlParts.Groups[3].Value;
-        }
+			var urlParts = Regex.Match(baseUrl, URL_SLICE_REGEXP, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+			Path = urlParts.Groups[1].Value;
+			QueryParams = QueryParamCollection.Parse(urlParts.Groups[2].Value);
+			Fragment = urlParts.Groups[3].Value;
+		}
 
 		/// <summary>
 		/// Basically a Path.Combine for URLs. Ensures exactly one '/' character is used to seperate each segment.
@@ -224,10 +224,10 @@ namespace Flurl
 		public string ToString(bool encodeStringAsPlus) {
 			var url = Path;
 			var query = QueryParams.ToString(encodeStringAsPlus);
-			if (query.Length > 0)
+			if(query.Length > 0)
 				url += "?" + query;
 
-            url += Fragment;
+			url += Fragment;
 
 			return url;
 		}

--- a/Flurl/Url.cs
+++ b/Flurl/Url.cs
@@ -1,6 +1,7 @@
-﻿using System;
+﻿using Flurl.Util;
+using System;
 using System.Collections.Generic;
-using Flurl.Util;
+using System.Text.RegularExpressions;
 
 namespace Flurl
 {
@@ -19,18 +20,26 @@ namespace Flurl
 		/// </summary>
 		public QueryParamCollection QueryParams { get; private set; }
 
-		/// <summary>
-		/// Constructs a Url object from a string.
-		/// </summary>
-		/// <param name="baseUrl">The URL to use as a starting point (required)</param>
-		public Url(string baseUrl) {
+        /// <summary>
+        /// The fragment part of the url (after the #, RFC 3986)
+        /// </summary>
+        public string Fragment { get; private set; }
+
+        const string URL_SLICE_REGEXP = @"^([^?#\n]*)([^#\n]*)(.*)$";
+
+        /// <summary>
+        /// Constructs a Url object from a string.
+        /// </summary>
+        /// <param name="baseUrl">The URL to use as a starting point (required)</param>
+        public Url(string baseUrl) {
 			if (baseUrl == null)
 				throw new ArgumentNullException("baseUrl");
 
-			var parts = baseUrl.Split('?');
-			Path = parts[0];
-			QueryParams = QueryParamCollection.Parse(parts.Length > 1 ? parts[1] : "");
-		}
+            var urlParts = Regex.Match(baseUrl, URL_SLICE_REGEXP, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+            Path = urlParts.Groups[1].Value;
+            QueryParams = QueryParamCollection.Parse(urlParts.Groups[2].Value);
+            Fragment = urlParts.Groups[3].Value;
+        }
 
 		/// <summary>
 		/// Basically a Path.Combine for URLs. Ensures exactly one '/' character is used to seperate each segment.
@@ -217,6 +226,8 @@ namespace Flurl
 			var query = QueryParams.ToString(encodeStringAsPlus);
 			if (query.Length > 0)
 				url += "?" + query;
+
+            url += Fragment;
 
 			return url;
 		}

--- a/NETCore/Flurl/project.json
+++ b/NETCore/Flurl/project.json
@@ -17,7 +17,8 @@
     "dotnet54": {
       "dependencies": {
         "System.Linq": "4.0.0",
-        "System.Reflection.TypeExtensions": "4.0.0"
+        "System.Reflection.TypeExtensions": "4.0.0",
+        "System.Text.RegularExpressions": "4.0.10",
       }
     }
   }

--- a/Test/Flurl.Test.Shared/UrlBuilderTests.cs
+++ b/Test/Flurl.Test.Shared/UrlBuilderTests.cs
@@ -262,44 +262,44 @@ namespace Flurl.Test
 			Assert.AreEqual(expected, url.ToString());
 		}
 
-        [Test]
-        public void is_fragment_parsed_in_url_without_querystring(){
-            var expected = "http://www.mysite.com/index#first";
-            var url = new Url(expected);
-            Assert.AreEqual(expected, url.ToString());
-        }
+		[Test]
+		public void is_fragment_parsed_in_url_without_querystring() {
+			var expected = "http://www.mysite.com/index#first";
+			var url = new Url(expected);
+			Assert.AreEqual(expected, url.ToString());
+		}
 
-        [Test]
-        public void is_fragment_parsed_in_url_with_querystring() {
-            var expected = "http://www.mysite.com/more?x=1#first";
-            var url = new Url(expected);
-            Assert.AreEqual(expected, url.ToString());
-        }
+		[Test]
+		public void is_fragment_parsed_in_url_with_querystring() {
+			var expected = "http://www.mysite.com/more?x=1#first";
+			var url = new Url(expected);
+			Assert.AreEqual(expected, url.ToString());
+		}
 
-        // Support Anchor / Hash URL parts #29
-        [Test]
-        public void has_fragment_after_SetQueryParam() {
-            var expected = "http://www.mysite.com/more?x=1#first";
-            var url = new Url(expected).SetQueryParam("x", 3);
-            Assert.AreEqual("http://www.mysite.com/more?x=3#first", url.ToString());
-        }
+		// Support Anchor / Hash URL parts #29
+		[Test]
+		public void has_fragment_after_SetQueryParam() {
+			var expected = "http://www.mysite.com/more?x=1#first";
+			var url = new Url(expected).SetQueryParam("x", 3);
+			Assert.AreEqual("http://www.mysite.com/more?x=3#first", url.ToString());
+		}
 
-        [Test]
-        public void constructor_parse_url_correctly() {
-            var simpleUrl = "http://www.mysite.com";
-            var simpleUrlWithEmptyQueryParam = simpleUrl + "?3423423";
-            var simpleUrlWithPath = simpleUrl + "/with/path";
-            var urlWithQueryString = simpleUrlWithPath + "?qs=2&z=3";
-            var urlWithEmtpyFragment = simpleUrlWithPath + "#";
-            var urlWithFragment = simpleUrlWithPath + "#something";
+		[Test]
+		public void constructor_parse_url_correctly() {
+			var simpleUrl = "http://www.mysite.com";
+			var simpleUrlWithEmptyQueryParam = simpleUrl + "?3423423";
+			var simpleUrlWithPath = simpleUrl + "/with/path";
+			var urlWithQueryString = simpleUrlWithPath + "?qs=2&z=3";
+			var urlWithEmtpyFragment = simpleUrlWithPath + "#";
+			var urlWithFragment = simpleUrlWithPath + "#something";
 
 
-            Assert.AreEqual(simpleUrl, new Url(simpleUrl).ToString());
-            Assert.AreEqual(simpleUrlWithEmptyQueryParam+"=", new Url(simpleUrlWithEmptyQueryParam).ToString());
-            Assert.AreEqual(simpleUrlWithPath, new Url(simpleUrlWithPath).ToString());
-            Assert.AreEqual(urlWithQueryString, new Url(urlWithQueryString).ToString());
-            Assert.AreEqual(urlWithEmtpyFragment, new Url(urlWithEmtpyFragment).ToString());
-            Assert.AreEqual(urlWithFragment, new Url(urlWithFragment).ToString());
-        }
-    }
+			Assert.AreEqual(simpleUrl, new Url(simpleUrl).ToString());
+			Assert.AreEqual(simpleUrlWithEmptyQueryParam + "=", new Url(simpleUrlWithEmptyQueryParam).ToString());
+			Assert.AreEqual(simpleUrlWithPath, new Url(simpleUrlWithPath).ToString());
+			Assert.AreEqual(urlWithQueryString, new Url(urlWithQueryString).ToString());
+			Assert.AreEqual(urlWithEmtpyFragment, new Url(urlWithEmtpyFragment).ToString());
+			Assert.AreEqual(urlWithFragment, new Url(urlWithFragment).ToString());
+		}
+	}
 }

--- a/Test/Flurl.Test.Shared/UrlBuilderTests.cs
+++ b/Test/Flurl.Test.Shared/UrlBuilderTests.cs
@@ -261,5 +261,45 @@ namespace Flurl.Test
 			var url = new Url(expected);
 			Assert.AreEqual(expected, url.ToString());
 		}
-	}
+
+        [Test]
+        public void is_fragment_parsed_in_url_without_querystring(){
+            var expected = "http://www.mysite.com/index#first";
+            var url = new Url(expected);
+            Assert.AreEqual(expected, url.ToString());
+        }
+
+        [Test]
+        public void is_fragment_parsed_in_url_with_querystring() {
+            var expected = "http://www.mysite.com/more?x=1#first";
+            var url = new Url(expected);
+            Assert.AreEqual(expected, url.ToString());
+        }
+
+        // Support Anchor / Hash URL parts #29
+        [Test]
+        public void has_fragment_after_SetQueryParam() {
+            var expected = "http://www.mysite.com/more?x=1#first";
+            var url = new Url(expected).SetQueryParam("x", 3);
+            Assert.AreEqual("http://www.mysite.com/more?x=3#first", url.ToString());
+        }
+
+        [Test]
+        public void constructor_parse_url_correctly() {
+            var simpleUrl = "http://www.mysite.com";
+            var simpleUrlWithEmptyQueryParam = simpleUrl + "?3423423";
+            var simpleUrlWithPath = simpleUrl + "/with/path";
+            var urlWithQueryString = simpleUrlWithPath + "?qs=2&z=3";
+            var urlWithEmtpyFragment = simpleUrlWithPath + "#";
+            var urlWithFragment = simpleUrlWithPath + "#something";
+
+
+            Assert.AreEqual(simpleUrl, new Url(simpleUrl).ToString());
+            Assert.AreEqual(simpleUrlWithEmptyQueryParam+"=", new Url(simpleUrlWithEmptyQueryParam).ToString());
+            Assert.AreEqual(simpleUrlWithPath, new Url(simpleUrlWithPath).ToString());
+            Assert.AreEqual(urlWithQueryString, new Url(urlWithQueryString).ToString());
+            Assert.AreEqual(urlWithEmtpyFragment, new Url(urlWithEmtpyFragment).ToString());
+            Assert.AreEqual(urlWithFragment, new Url(urlWithFragment).ToString());
+        }
+    }
 }


### PR DESCRIPTION
Fix for #29

URL fragment support added.
Changed Url class' ctor to use regexp instead of string splitting.
Tests included.