### PR TITLE
Fix PCL\mobile targets

### DIFF
--- a/Build/nuspec/Flurl.Http.nuspec
+++ b/Build/nuspec/Flurl.Http.nuspec
@@ -42,56 +42,49 @@
 		</releaseNotes>
 		<tags>httpclient rest json http fluent portable url uri tdd assert async</tags>
 		<dependencies>
-			<group targetFramework="MonoAndroid1.0">
+			<group targetFramework="net45">
 				<dependency id="Newtonsoft.Json" version="8.0.3" />
-				<dependency id="Flurl" version="2.1.0-beta3-update1" />
+				<dependency id="Flurl" version="2.1.0-beta3-update3" />
 			</group>
-			<group targetFramework="MonoTouch1.0">
+			<group targetFramework="net46">
 				<dependency id="Newtonsoft.Json" version="8.0.3" />
-				<dependency id="Flurl" version="2.1.0-beta3-update1" />
+				<dependency id="Flurl" version="2.1.0-beta3-update3" />
+				<dependency id="System.IO.FileSystem" version="4.0.0" />
 			</group>
-			<group targetFramework="Xamarin.iOS1.0">
+			<group targetFramework="monoandroid">
 				<dependency id="Newtonsoft.Json" version="8.0.3" />
-				<dependency id="Flurl" version="2.1.0-beta3-update1" />
+				<dependency id="Flurl" version="2.1.0-beta3-update3" />
 			</group>
-			<group targetFramework="Xamarin.Mac2.0">
+			<group targetFramework="monotouch">
 				<dependency id="Newtonsoft.Json" version="8.0.3" />
-				<dependency id="Flurl" version="2.1.0-beta3-update1" />
+				<dependency id="Flurl" version="2.1.0-beta3-update3" />
 			</group>
-			<group targetFramework="Xamarin.TVOS1.0">
+			<group targetFramework="xamarin.ios">
 				<dependency id="Newtonsoft.Json" version="8.0.3" />
-				<dependency id="Flurl" version="2.1.0-beta3-update1" />
+				<dependency id="Flurl" version="2.1.0-beta3-update3" />
 			</group>
-			<group targetFramework="Xamarin.WatchOS1.0">
+			<group targetFramework="xamarin.mac">
 				<dependency id="Newtonsoft.Json" version="8.0.3" />
-				<dependency id="Flurl" version="2.1.0-beta3-update1" />
+				<dependency id="Flurl" version="2.1.0-beta3-update3" />
 			</group>
 			<group targetFramework="portable45-net45+win8+wpa81">
 				<dependency id="Newtonsoft.Json" version="8.0.3" />
-				<dependency id="Flurl" version="2.1.0-beta3-update1" />
+				<dependency id="Flurl" version="2.1.0-beta3-update3" />
 				<dependency id="Microsoft.Bcl.Async" version="1.0.168" />
 				<dependency id="Microsoft.Net.Http" version="2.2.29" />
 				<dependency id="PCLStorage" version="1.0.2" />
 			</group>
-	    <group targetFramework="net45">
-				<dependency id="Newtonsoft.Json" version="8.0.3" />
-				<dependency id="Flurl" version="2.1.0-beta3-update1" />
-			</group>
-			<group targetFramework="net46">
-				<dependency id="Newtonsoft.Json" version="8.0.3" />
-				<dependency id="Flurl" version="2.1.0-beta3-update1" />
-				<dependency id="System.IO.FileSystem" version="4.0.0" />
-			</group>
 			<group targetFramework="uap10">
 				<dependency id="Newtonsoft.Json" version="8.0.3" />
-				<dependency id="Flurl" version="2.1.0-beta3-update1" />
+				<dependency id="Flurl" version="2.1.0-beta3-update3" />
 			</group>
-			<group targetFramework=".NETStandard1.3">
+			<group targetFramework="netstandard1.4">
 				<dependency id="Newtonsoft.Json" version="8.0.3" />
-				<dependency id="Flurl" version="2.1.0-beta3-update1" />
+				<dependency id="Flurl" version="2.1.0-beta3-update3" />
 				<dependency id="System.Dynamic.Runtime" version="4.0.11-rc2-24027" />
 				<dependency id="System.IO.FileSystem" version="4.0.1-rc2-24027" />
 				<dependency id="System.Net.Http" version="4.0.1-rc2-24027" />
+				<dependency id="System.Runtime.Extensions" version="4.1.0-rc2-24027" />
 				<dependency id="System.Runtime.Serialization.Primitives" version="4.1.1-rc2-24027" />
 				<dependency id="System.Text.RegularExpressions" version="4.0.12-rc2-24027" />
 				<dependency id="System.Threading" version="4.0.11-rc2-24027" />

--- a/Build/nuspec/Flurl.Http.nuspec
+++ b/Build/nuspec/Flurl.Http.nuspec
@@ -2,7 +2,7 @@
 <package >
 	<metadata>
 		<id>Flurl.Http</id>
-		<version>1.0.0-beta3</version>
+		<version>1.0.0-beta4</version>
 		<title>Flurl.Http</title>
 		<authors>Todd Menier</authors>
 		<projectUrl>http://tmenier.github.io/Flurl</projectUrl>
@@ -44,57 +44,57 @@
 		<dependencies>
 			<group targetFramework="MonoAndroid1.0">
 				<dependency id="Newtonsoft.Json" version="8.0.3" />
-				<dependency id="Flurl" version="2.1.0-beta2" />
+				<dependency id="Flurl" version="2.1.0-beta3-update1" />
 			</group>
 			<group targetFramework="MonoTouch1.0">
 				<dependency id="Newtonsoft.Json" version="8.0.3" />
-				<dependency id="Flurl" version="2.1.0-beta2" />
+				<dependency id="Flurl" version="2.1.0-beta3-update1" />
 			</group>
 			<group targetFramework="Xamarin.iOS1.0">
 				<dependency id="Newtonsoft.Json" version="8.0.3" />
-				<dependency id="Flurl" version="2.1.0-beta2" />
+				<dependency id="Flurl" version="2.1.0-beta3-update1" />
 			</group>
 			<group targetFramework="Xamarin.Mac2.0">
 				<dependency id="Newtonsoft.Json" version="8.0.3" />
-				<dependency id="Flurl" version="2.1.0-beta2" />
+				<dependency id="Flurl" version="2.1.0-beta3-update1" />
 			</group>
 			<group targetFramework="Xamarin.TVOS1.0">
 				<dependency id="Newtonsoft.Json" version="8.0.3" />
-				<dependency id="Flurl" version="2.1.0-beta2" />
+				<dependency id="Flurl" version="2.1.0-beta3-update1" />
 			</group>
 			<group targetFramework="Xamarin.WatchOS1.0">
 				<dependency id="Newtonsoft.Json" version="8.0.3" />
-				<dependency id="Flurl" version="2.1.0-beta2" />
+				<dependency id="Flurl" version="2.1.0-beta3-update1" />
 			</group>
 			<group targetFramework="portable45-net45+win8+wpa81">
 				<dependency id="Newtonsoft.Json" version="8.0.3" />
-				<dependency id="Flurl" version="2.1.0-beta2" />
+				<dependency id="Flurl" version="2.1.0-beta3-update1" />
 				<dependency id="Microsoft.Bcl.Async" version="1.0.168" />
 				<dependency id="Microsoft.Net.Http" version="2.2.29" />
 				<dependency id="PCLStorage" version="1.0.2" />
 			</group>
-	                <group targetFramework="net45">
+	    <group targetFramework="net45">
 				<dependency id="Newtonsoft.Json" version="8.0.3" />
-				<dependency id="Flurl" version="2.1.0-beta2" />
+				<dependency id="Flurl" version="2.1.0-beta3-update1" />
 			</group>
 			<group targetFramework="net46">
 				<dependency id="Newtonsoft.Json" version="8.0.3" />
-				<dependency id="Flurl" version="2.1.0-beta2" />
+				<dependency id="Flurl" version="2.1.0-beta3-update1" />
 				<dependency id="System.IO.FileSystem" version="4.0.0" />
 			</group>
 			<group targetFramework="uap10">
 				<dependency id="Newtonsoft.Json" version="8.0.3" />
-				<dependency id="Flurl" version="2.1.0-beta2" />
+				<dependency id="Flurl" version="2.1.0-beta3-update1" />
 			</group>
-			<group targetFramework=".NETStandard1.4">
+			<group targetFramework=".NETStandard1.3">
 				<dependency id="Newtonsoft.Json" version="8.0.3" />
-				<dependency id="Flurl" version="2.1.0-beta2" />
-				<dependency id="System.Dynamic.Runtime" version="4.0.10" />
-				<dependency id="System.IO.FileSystem" version="4.0.0" />
-				<dependency id="System.Net.Http" version="4.0.0" />
-				<dependency id="System.Runtime.Serialization.Primitives" version="4.1.0" />
-				<dependency id="System.Text.RegularExpressions" version="4.0.10" />
-				<dependency id="System.Threading" version="4.0.10" />
+				<dependency id="Flurl" version="2.1.0-beta3-update1" />
+				<dependency id="System.Dynamic.Runtime" version="4.0.11-rc2-24027" />
+				<dependency id="System.IO.FileSystem" version="4.0.1-rc2-24027" />
+				<dependency id="System.Net.Http" version="4.0.1-rc2-24027" />
+				<dependency id="System.Runtime.Serialization.Primitives" version="4.1.1-rc2-24027" />
+				<dependency id="System.Text.RegularExpressions" version="4.0.12-rc2-24027" />
+				<dependency id="System.Threading" version="4.0.11-rc2-24027" />
 			</group>
 		</dependencies>
 	</metadata>

--- a/Build/nuspec/Flurl.nuspec
+++ b/Build/nuspec/Flurl.nuspec
@@ -2,7 +2,7 @@
 <package >
 	<metadata>
 		<id>Flurl</id>
-		<version>2.1.0-beta3-update1</version>
+		<version>2.1.0-beta3-update3</version>
 		<title>Flurl</title>
 		<authors>Todd Menier</authors>
 		<projectUrl>http://tmenier.github.io/Flurl</projectUrl>
@@ -35,20 +35,16 @@
 		</releaseNotes>
 		<tags>fluent portable url uri querystring builder</tags>
 		<dependencies>
-			<group targetFramework="MonoAndroid1.0" />
-			<group targetFramework="MonoTouch1.0" />
 			<group targetFramework="net40" />
-			<group targetFramework="net45" />
-			<group targetFramework="net46" />
+			<group targetFramework="win8" />
+			<group targetFramework="wpa81" />
+			<group targetFramework="xamarin.ios" />
+			<group targetFramework="xamarin.mac" />
+			<group targetFramework="monotouch" />
+			<group targetFramework="monoandroid" />
 			<group targetFramework="uap10" />
 			<group targetFramework="portable40-net40+win8+wpa81" />
-			<group targetFramework="Windows8.0" />
-			<group targetFramework="WindowsPhoneApp8.1" />
-			<group targetFramework="Xamarin.iOS1.0" />
-			<group targetFramework="Xamarin.Mac2.0" />
-			<group targetFramework="Xamarin.TVOS1.0" />
-			<group targetFramework="Xamarin.WatchOS1.0" />
-			<group targetFramework=".NETStandard1.3">
+			<group targetFramework="netstandard1.4">
 				<dependency id="System.Globalization" version= "4.0.11-rc2-24027" />
 				<dependency id="System.Linq" version="4.1.0-rc2-24027" />
 				<dependency id="System.Reflection.TypeExtensions" version="4.1.0-rc2-24027" />
@@ -56,8 +52,7 @@
 		</dependencies>
 	</metadata>
 	<files>
-		<file src="..\..\src\Flurl.Library\bin\Release\portable40-net40+win8+wpa81\Flurl.*" target="lib\portable40-net40+win8+wpa81" />
-		<file src="..\..\src\Flurl.Library\bin\Release\portable40-net40+win8+wpa81\Flurl.*" target="lib\MonoAndroid10" />
-		<file src="..\..\src\Flurl.Library\bin\Release\netstandard1.3\Flurl.*" target="lib\netstandard1.3" />
+		<file src="..\..\src\Flurl.Library\bin\Release\portable40-net40+win8+wpa81\Flurl.*" target="lib\portable-net40+win8+wpa81+monoandroid+monotouch+xamarin.ios+xamarin.mac" />
+		<file src="..\..\src\Flurl.Library\bin\Release\netstandard1.4\Flurl.*" target="lib\netstandard1.4" />
 	</files>
 </package>

--- a/Build/nuspec/Flurl.nuspec
+++ b/Build/nuspec/Flurl.nuspec
@@ -1,8 +1,8 @@
-<?xml version="1.0"?>
+﻿<?xml version="1.0"?>
 <package >
 	<metadata>
 		<id>Flurl</id>
-		<version>2.1.0-beta2</version>
+		<version>2.1.0-beta3-update1</version>
 		<title>Flurl</title>
 		<authors>Todd Menier</authors>
 		<projectUrl>http://tmenier.github.io/Flurl</projectUrl>
@@ -39,21 +39,25 @@
 			<group targetFramework="MonoTouch1.0" />
 			<group targetFramework="net40" />
 			<group targetFramework="net45" />
+			<group targetFramework="net46" />
 			<group targetFramework="uap10" />
-			<group targetFramework="portable45-net45+win8+wpa81" />
+			<group targetFramework="portable40-net40+win8+wpa81" />
 			<group targetFramework="Windows8.0" />
 			<group targetFramework="WindowsPhoneApp8.1" />
 			<group targetFramework="Xamarin.iOS1.0" />
 			<group targetFramework="Xamarin.Mac2.0" />
 			<group targetFramework="Xamarin.TVOS1.0" />
 			<group targetFramework="Xamarin.WatchOS1.0" />
-			<group targetFramework=".NETStandard1.1">
-				<dependency id="System.Linq" version="4.0.0" />
-				<dependency id="System.Reflection.TypeExtensions" version="4.0.0" />
+			<group targetFramework=".NETStandard1.3">
+				<dependency id="System.Globalization" version= "4.0.11-rc2-24027" />
+				<dependency id="System.Linq" version="4.1.0-rc2-24027" />
+				<dependency id="System.Reflection.TypeExtensions" version="4.1.0-rc2-24027" />
 			</group>
 		</dependencies>
 	</metadata>
 	<files>
-		<file src="..\..\src\Flurl.Library\bin\Release\**\Flurl.*" target="lib\" />
+		<file src="..\..\src\Flurl.Library\bin\Release\portable40-net40+win8+wpa81\Flurl.*" target="lib\portable40-net40+win8+wpa81" />
+		<file src="..\..\src\Flurl.Library\bin\Release\portable40-net40+win8+wpa81\Flurl.*" target="lib\MonoAndroid10" />
+		<file src="..\..\src\Flurl.Library\bin\Release\netstandard1.3\Flurl.*" target="lib\netstandard1.3" />
 	</files>
 </package>

--- a/PackageTesters/PackageTester.NET45/PackageTester.NET45.csproj
+++ b/PackageTesters/PackageTester.NET45/PackageTester.NET45.csproj
@@ -37,11 +37,11 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Flurl, Version=2.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Flurl.2.1.0-beta2\lib\net40\Flurl.dll</HintPath>
+      <HintPath>..\..\packages\Flurl.2.1.0-beta3-update3\lib\portable-net40+win8+wpa81+monoandroid+monotouch+xamarin.ios+xamarin.mac\Flurl.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Flurl.Http, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Flurl.Http.1.0.0-beta3\lib\portable45-net45+win8+wpa81\Flurl.Http.dll</HintPath>
+      <HintPath>..\..\packages\Flurl.Http.1.0.0-beta4\lib\portable45-net45+win8+wpa81\Flurl.Http.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Threading.Tasks, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/PackageTesters/PackageTester.NET45/packages.config
+++ b/PackageTesters/PackageTester.NET45/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Flurl" version="2.1.0-beta2" targetFramework="net45" />
-  <package id="Flurl.Http" version="1.0.0-beta3" targetFramework="net45" />
+  <package id="Flurl" version="2.1.0-beta3-update3" targetFramework="net45" />
+  <package id="Flurl.Http" version="1.0.0-beta4" targetFramework="net45" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net45" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net45" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net45" />

--- a/PackageTesters/PackageTester.NET461/App.config
+++ b/PackageTesters/PackageTester.NET461/App.config
@@ -9,6 +9,14 @@
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO.FileSystem" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO.FileSystem.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/PackageTesters/PackageTester.NET461/PackageTester.NET461.csproj
+++ b/PackageTesters/PackageTester.NET461/PackageTester.NET461.csproj
@@ -35,11 +35,11 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Flurl, Version=2.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Flurl.2.1.0-beta2\lib\net40\Flurl.dll</HintPath>
+      <HintPath>..\..\packages\Flurl.2.1.0-beta3-update3\lib\netstandard1.4\Flurl.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Flurl.Http, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Flurl.Http.1.0.0-beta3\lib\netstandard1.4\Flurl.Http.dll</HintPath>
+      <HintPath>..\..\packages\Flurl.Http.1.0.0-beta4\lib\netstandard1.4\Flurl.Http.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">

--- a/PackageTesters/PackageTester.NET461/packages.config
+++ b/PackageTesters/PackageTester.NET461/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Flurl" version="2.1.0-beta2" targetFramework="net461" />
-  <package id="Flurl.Http" version="1.0.0-beta3" targetFramework="net461" />
+  <package id="Flurl" version="2.1.0-beta3-update3" targetFramework="net461" />
+  <package id="Flurl.Http" version="1.0.0-beta4" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net461" />
   <package id="System.IO" version="4.0.10" targetFramework="net461" />
   <package id="System.IO.FileSystem" version="4.0.0" targetFramework="net461" />

--- a/PackageTesters/PackageTester.NETCore/project.json
+++ b/PackageTesters/PackageTester.NETCore/project.json
@@ -5,7 +5,9 @@
       "include": [ "../PackageTester.Shared/**/*.cs" ]
     }
   },
-
+  "dependencies": {
+    "Flurl.Http": "1.0.0-beta4"
+  },
   "frameworks": {
     "netcoreapp1.0": {
       "imports": "dnxcore50",
@@ -16,9 +18,5 @@
         }
       }
     }
-  },
-
-  "dependencies": {
-    "Flurl.Http": "1.0.0-beta3"
   }
 }

--- a/PackageTesters/PackageTester.PCL/PackageTester.PCL.csproj
+++ b/PackageTesters/PackageTester.PCL/PackageTester.PCL.csproj
@@ -50,11 +50,11 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Flurl, Version=2.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Flurl.2.1.0-beta2\lib\netstandard1.1\Flurl.dll</HintPath>
+      <HintPath>..\..\packages\Flurl.2.1.0-beta3-update3\lib\portable-net40+win8+wpa81+monoandroid+monotouch+xamarin.ios+xamarin.mac\Flurl.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Flurl.Http, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Flurl.Http.1.0.0-beta3\lib\portable45-net45+win8+wpa81\Flurl.Http.dll</HintPath>
+      <HintPath>..\..\packages\Flurl.Http.1.0.0-beta4\lib\portable45-net45+win8+wpa81\Flurl.Http.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Threading.Tasks, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/PackageTesters/PackageTester.PCL/packages.config
+++ b/PackageTesters/PackageTester.PCL/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Flurl" version="2.1.0-beta2" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="Flurl.Http" version="1.0.0-beta3" targetFramework="portable45-net45+win8+wpa81" />
+  <package id="Flurl" version="2.1.0-beta3-update3" targetFramework="portable45-net45+win8+wpa81" />
+  <package id="Flurl.Http" version="1.0.0-beta4" targetFramework="portable45-net45+win8+wpa81" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="portable45-net45+win8+wpa81" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="portable45-net45+win8+wpa81" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="portable45-net45+win8+wpa81" />

--- a/Test/Flurl.Test.NET45/Flurl.Test.NET45.csproj
+++ b/Test/Flurl.Test.NET45/Flurl.Test.NET45.csproj
@@ -19,7 +19,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;NETSTD</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NET45</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
@@ -27,7 +27,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE;NETSTD</DefineConstants>
+    <DefineConstants>TRACE;NET45</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>

--- a/Test/Flurl.Test.NETCore/project.json
+++ b/Test/Flurl.Test.NETCore/project.json
@@ -3,7 +3,7 @@
 
   "buildOptions": {
     "compile": {
-      "include": [ "../Flurl.Test.Shared/**/*.cs", "../../src/Flurl.Shared/**/*.cs", "../../src/Flurl.Http.Shared/**/*.cs" ]
+      "include": [ "../Flurl.Test.Shared/**/*.cs" ]
     },
     "emitEntryPoint": true
   },
@@ -14,15 +14,14 @@
 
   "dependencies": {
     "NUnitLite": "3.2.1",
-    "Newtonsoft.Json": "8.0.3",
-    "System.Runtime.Serialization.Primitives": "4.1.0"
+    "Flurl.Http.Library": {
+      "version": "",
+      "target": "project"
+    }
   },
 
   "frameworks": {
     "netcoreapp1.0": {
-      "buildOptions": {
-        "define": [ "NETSTD" ]
-      },
       "imports": "dnxcore50",
       "dependencies": {
         "Microsoft.NETCore.App": {

--- a/Test/Flurl.Test.Shared/Http/FlurlClientTests.cs
+++ b/Test/Flurl.Test.Shared/Http/FlurlClientTests.cs
@@ -1,4 +1,4 @@
-﻿#if !NETSTD
+﻿#if !NETCOREAPP1_0
 using System.Linq;
 using Flurl.Http;
 using NUnit.Framework;

--- a/Test/Flurl.Test.Shared/Http/RealHttpTests.cs
+++ b/Test/Flurl.Test.Shared/Http/RealHttpTests.cs
@@ -15,7 +15,7 @@ namespace Flurl.Test.Http
 	[TestFixture]
 	public class RealHttpTests
 	{
-#if NETSTD
+#if NET45 || NETCORE
 		[Test]
 		public async Task can_download_file() {
 			var path = await "http://www.google.com".DownloadFileAsync(@"c:\a\b", "google.txt");

--- a/Test/Flurl.Test.Shared/ReflectionHelper.cs
+++ b/Test/Flurl.Test.Shared/ReflectionHelper.cs
@@ -1,4 +1,4 @@
-﻿#if !NETSTD
+﻿#if !NETCOREAPP1_0
 using System;
 using System.Linq;
 using System.Reflection;

--- a/Test/Flurl.Test.Shared/UrlBuilderTests.cs
+++ b/Test/Flurl.Test.Shared/UrlBuilderTests.cs
@@ -13,7 +13,7 @@ namespace Flurl.Test
     public class UrlBuilderTests
     {
 
-#if !NETSTD
+#if !NETCOREAPP1_0
         [Test]
         // check that for every Url method, we have an equivalent string extension
         public void extension_methods_consistently_supported()
@@ -233,7 +233,7 @@ namespace Flurl.Test
             Assert.AreEqual("http://www.mysite.com/more", url.ToString());
         }
 
-#if !NETSTD
+#if !NETCOREAPP1_0
         [Test]
         public void url_ToString_uses_invariant_culture()
         {

--- a/src/Flurl.Http.Library/project.json
+++ b/src/Flurl.Http.Library/project.json
@@ -3,7 +3,7 @@
   "version": "1.0.0-beta4",
 
   "dependencies": {
-    "Flurl": "2.1.0-beta3-update1",
+    "Flurl": "2.1.0-beta3-update3",
     "Newtonsoft.Json": "8.0.3"
   },
 
@@ -36,15 +36,13 @@
         "System.Threading": "4.0.0.0"
       }
     },
-    "netstandard1.3": {
-      "buildOptions": {
-        "define": [ "NETSTD" ]
-      },
+    "netstandard1.4": {
       "imports": "dnxcore50",
       "dependencies": {
         "System.Dynamic.Runtime": "4.0.11-rc2-24027",
         "System.IO.FileSystem": "4.0.1-rc2-24027",
         "System.Net.Http": "4.0.1-rc2-24027",
+        "System.Runtime.Extensions": "4.1.0-rc2-24027",
         "System.Runtime.Serialization.Primitives": "4.1.1-rc2-24027",
         "System.Text.RegularExpressions": "4.0.12-rc2-24027",
         "System.Threading": "4.0.11-rc2-24027"

--- a/src/Flurl.Http.Library/project.json
+++ b/src/Flurl.Http.Library/project.json
@@ -1,9 +1,9 @@
-﻿{
+{
   "title": "Flurl.Http",
-  "version": "1.0.0-beta3",
+  "version": "1.0.0-beta4",
 
   "dependencies": {
-    "Flurl": "2.1.0-beta2",
+    "Flurl": "2.1.0-beta3-update1",
     "Newtonsoft.Json": "8.0.3"
   },
 
@@ -18,8 +18,9 @@
 
   "frameworks": {
     "portable45-net45+win8+wpa81": {
-      "buildOptions": { 
-        "define": [ "PORTABLE" ] },
+      "buildOptions": {
+        "define": [ "PORTABLE" ]
+      },
       "dependencies": {
         "Microsoft.Bcl.Async": "1.0.168",
         "Microsoft.Net.Http": "2.2.29",
@@ -35,17 +36,18 @@
         "System.Threading": "4.0.0.0"
       }
     },
-    "netstandard1.4": {
-      "buildOptions": { 
-        "define": [ "NETSTD" ] },
+    "netstandard1.3": {
+      "buildOptions": {
+        "define": [ "NETSTD" ]
+      },
       "imports": "dnxcore50",
       "dependencies": {
-        "System.Dynamic.Runtime": "4.0.10",
-        "System.IO.FileSystem": "4.0.0",
-        "System.Net.Http": "4.0.0",
-        "System.Runtime.Serialization.Primitives": "4.1.0",
-        "System.Text.RegularExpressions": "4.0.10",
-        "System.Threading": "4.0.10"
+        "System.Dynamic.Runtime": "4.0.11-rc2-24027",
+        "System.IO.FileSystem": "4.0.1-rc2-24027",
+        "System.Net.Http": "4.0.1-rc2-24027",
+        "System.Runtime.Serialization.Primitives": "4.1.1-rc2-24027",
+        "System.Text.RegularExpressions": "4.0.12-rc2-24027",
+        "System.Threading": "4.0.11-rc2-24027"
       }
     }
   }

--- a/src/Flurl.Http.Shared/DownloadExtensions.cs
+++ b/src/Flurl.Http.Shared/DownloadExtensions.cs
@@ -1,4 +1,4 @@
-﻿#if NETSTD
+﻿#if NETSTANDARD1_4 || NET45
 using System.IO;
 #elif PORTABLE
 using PCLStorage;
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 
 namespace Flurl.Http
 {
-#if NETSTD
+#if NETSTANDARD1_4 || NET45
 	/// <summary>
 	/// Download extensions for the Flurl Client.
 	/// </summary>

--- a/src/Flurl.Http.Shared/NoOpTask.cs
+++ b/src/Flurl.Http.Shared/NoOpTask.cs
@@ -4,7 +4,7 @@ namespace Flurl.Http
 {
     internal static class NoOpTask
     {
-#if NETSTD
+#if NETSTANDARD1_4 || NET45
         public static readonly Task Instance = Task.FromResult(0);
 #elif PORTABLE
         public static readonly Task Instance = TaskEx.FromResult(0);

--- a/src/Flurl.Library/project.json
+++ b/src/Flurl.Library/project.json
@@ -1,6 +1,6 @@
 {
   "title": "Flurl",
-  "version": "2.1.0-beta3-update1",
+  "version": "2.1.0-beta3-update3",
 
   "buildOptions": {
     "compile": {
@@ -19,10 +19,7 @@
         "System.Core": "2.0.5.0"
       }
     },
-    "netstandard1.3": {
-      "buildOptions": {
-        "define": [ "NETSTD" ]
-      },
+    "netstandard1.4": {
       "dependencies": {
         "System.Globalization": "4.0.11-rc2-24027",
         "System.Linq": "4.1.0-rc2-24027",

--- a/src/Flurl.Library/project.json
+++ b/src/Flurl.Library/project.json
@@ -1,6 +1,6 @@
 {
   "title": "Flurl",
-  "version": "2.1.0-beta2",
+  "version": "2.1.0-beta3-update1",
 
   "buildOptions": {
     "compile": {
@@ -12,12 +12,21 @@
   },
 
   "frameworks": {
-    "net40": { },
-    "netstandard1.1": {
-      "imports": "dotnet51",
+    "portable40-net40+win8+wpa81": {
+      "frameworkAssemblies": {
+        "mscorlib": "2.0.5.0",
+        "System": "2.0.5.0",
+        "System.Core": "2.0.5.0"
+      }
+    },
+    "netstandard1.3": {
+      "buildOptions": {
+        "define": [ "NETSTD" ]
+      },
       "dependencies": {
-        "System.Linq": "4.0.0",
-        "System.Reflection.TypeExtensions": "4.0.0"
+        "System.Globalization": "4.0.11-rc2-24027",
+        "System.Linq": "4.1.0-rc2-24027",
+        "System.Reflection.TypeExtensions": "4.1.0-rc2-24027"
       }
     }
   }

--- a/src/Flurl.Shared/Util/CommonExtensions.cs
+++ b/src/Flurl.Shared/Util/CommonExtensions.cs
@@ -3,7 +3,9 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+#if NETSTD
 using System.Reflection;
+#endif
 
 namespace Flurl.Util
 {

--- a/src/Flurl.Shared/Util/CommonExtensions.cs
+++ b/src/Flurl.Shared/Util/CommonExtensions.cs
@@ -3,7 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-#if NETSTD
+#if NETSTANDARD1_4
 using System.Reflection;
 #endif
 


### PR DESCRIPTION
1. Back Flurl PCL target. Try to fix Xamarin Reflections problems. Xamarin uses netstandard dll, not PCL. Why? I dont know.
2. Bump versions of packages to netstandard 1.4
3. Testing win10 UPA and Xamarin packages.

**Please merge this PR AFTER tests will done.**