### PR TITLE
Develop fix for #128

### DIFF
--- a/Build/nuspec/Flurl.Http.nuspec
+++ b/Build/nuspec/Flurl.Http.nuspec
@@ -2,7 +2,7 @@
 <package >
 	<metadata>
 		<id>Flurl.Http</id>
-		<version>1.0.1</version>
+		<version>1.0.2</version>
 		<title>Flurl.Http</title>
 		<authors>Todd Menier</authors>
 		<projectUrl>http://tmenier.github.io/Flurl</projectUrl>
@@ -13,6 +13,7 @@
 			A fluent, portable, testable HTTP client library that extends Flurl's URL builder chain.
 		</description>
 		<releaseNotes>
+1.0.2 - Updated Flurl dependency to 2.2.1 https://www.nuget.org/packages/Flurl/2.2.1   
 1.0.1 - Updated Flurl dependency to 2.2 https://www.nuget.org/packages/Flurl/2.2.0
 1.0.0 - Many updates and new features: https://github.com/tmenier/Flurl/releases/tag/Flurl.Http.1.0.0
 0.10.1 - DLL version fix (github #90)
@@ -45,18 +46,18 @@
 		<dependencies>
 			<group targetFramework="net45">
 				<dependency id="Newtonsoft.Json" version="9.0.1" />
-				<dependency id="Flurl" version="2.2.0" />
+				<dependency id="Flurl" version="2.2.1" />
 			</group>
 			<group targetFramework="net461">
 				<dependency id="Newtonsoft.Json" version="9.0.1" />
-				<dependency id="Flurl" version="2.2.0" />
+				<dependency id="Flurl" version="2.2.1" />
 				<dependency id="System.IO.FileSystem" version="4.0.1" />
 				<dependency id="System.Net.Http" version="4.1.0" />
 				<dependency id="System.Text.Encoding.CodePages" version="4.0.1" />
 			</group>  
 			<group targetFramework="monoandroid">
 				<dependency id="Newtonsoft.Json" version="9.0.1" />
-				<dependency id="Flurl" version="2.2.0" />
+				<dependency id="Flurl" version="2.2.1" />
 				<dependency id="Microsoft.Bcl.Async" version="1.0.168" />
 				<dependency id="Microsoft.Bcl.Build" version="1.0.21" />
 				<dependency id="Microsoft.Net.Http" version="2.2.29" />
@@ -64,7 +65,7 @@
 			</group>
 			<group targetFramework="monotouch">
 				<dependency id="Newtonsoft.Json" version="9.0.1" />
-				<dependency id="Flurl" version="2.2.0" />
+				<dependency id="Flurl" version="2.2.1" />
 				<dependency id="Microsoft.Bcl.Async" version="1.0.168" />
 				<dependency id="Microsoft.Bcl.Build" version="1.0.21" />
 				<dependency id="Microsoft.Net.Http" version="2.2.29" />
@@ -72,7 +73,7 @@
 			</group>
 			<group targetFramework="xamarin.ios">
 				<dependency id="Newtonsoft.Json" version="9.0.1" />
-				<dependency id="Flurl" version="2.2.0" />
+				<dependency id="Flurl" version="2.2.1" />
 				<dependency id="Microsoft.Bcl.Async" version="1.0.168" />
 				<dependency id="Microsoft.Bcl.Build" version="1.0.21" />
 				<dependency id="Microsoft.Net.Http" version="2.2.29" />
@@ -80,7 +81,7 @@
 			</group>
 			<group targetFramework="xamarin.mac">
 				<dependency id="Newtonsoft.Json" version="9.0.1" />
-				<dependency id="Flurl" version="2.2.0" />
+				<dependency id="Flurl" version="2.2.1" />
 				<dependency id="Microsoft.Bcl.Async" version="1.0.168" />
 				<dependency id="Microsoft.Bcl.Build" version="1.0.21" />
 				<dependency id="Microsoft.Net.Http" version="2.2.29" />
@@ -88,7 +89,7 @@
 			</group>
 			<group targetFramework="portable40-net45+sl5+win8+wp8+wpa81">
 				<dependency id="Newtonsoft.Json" version="9.0.1" />
-				<dependency id="Flurl" version="2.2.0" />
+				<dependency id="Flurl" version="2.2.1" />
 				<dependency id="Microsoft.Bcl.Async" version="1.0.168" />
 				<dependency id="Microsoft.Bcl.Build" version="1.0.21" />
 				<dependency id="Microsoft.Net.Http" version="2.2.29" />
@@ -96,11 +97,11 @@
 			</group>
 			<group targetFramework="uap10">
 				<dependency id="Newtonsoft.Json" version="9.0.1" />
-				<dependency id="Flurl" version="2.2.0" />
+				<dependency id="Flurl" version="2.2.1" />
 			</group>
 			<group targetFramework="netstandard1.4">
 				<dependency id="Newtonsoft.Json" version="9.0.1" />
-				<dependency id="Flurl" version="2.2.0" />
+				<dependency id="Flurl" version="2.2.1" />
 				<dependency id="System.IO.FileSystem" version="4.0.1" />
 				<dependency id="System.Net.Http" version="4.1.0" />
 				<dependency id="System.Text.Encoding.CodePages" version="4.0.1" />

--- a/Build/nuspec/Flurl.nuspec
+++ b/Build/nuspec/Flurl.nuspec
@@ -2,7 +2,7 @@
 <package >
 	<metadata>
 		<id>Flurl</id>
-		<version>2.2.0</version>
+		<version>2.2.1</version>
 		<title>Flurl</title>
 		<authors>Todd Menier</authors>
 		<projectUrl>http://tmenier.github.io/Flurl</projectUrl>
@@ -13,6 +13,7 @@
 			A fluent, portable URL builder. To make HTTP calls off the fluent chain, check out Flurl.Http.
 		</description>
 		<releaseNotes>
+2.2.1 - Fix net461 target (github #128)      
 2.2.0 - Url.Combine enhancements, broader PCL support https://github.com/tmenier/Flurl/releases/tag/Flurl.2.2.0
 2.1.0 - .NET Core 1.0.0 support. Target .NET Platform Standard 1.4
 2.0.0 - BREAKING CHANGES: https://github.com/tmenier/Flurl/wiki/Release-Notes
@@ -37,6 +38,11 @@
 		<tags>fluent portable url uri querystring builder</tags>
 		<dependencies>
 			<group targetFramework="net40" />
+			<group targetFramework="net461">
+				<dependency id="System.Globalization.Calendars" version="4.0.1" />
+				<dependency id="System.Linq" version="4.1.0" />
+				<dependency id="System.Reflection.TypeExtensions" version="4.1.0" />
+			</group>
 			<group targetFramework="win8" />
 			<group targetFramework="wpa81" />
 			<group targetFramework="xamarin.ios" />

--- a/Build/nuspec/Flurl.nuspec
+++ b/Build/nuspec/Flurl.nuspec
@@ -39,7 +39,7 @@
 		<dependencies>
 			<group targetFramework="net40" />
 			<group targetFramework="net461">
-				<dependency id="System.Globalization.Calendars" version="4.0.1" />
+				<dependency id="System.Globalization" version="4.0.11" />
 				<dependency id="System.Linq" version="4.1.0" />
 				<dependency id="System.Reflection.TypeExtensions" version="4.1.0" />
 			</group>
@@ -52,7 +52,7 @@
 			<group targetFramework="uap10" />
 			<group targetFramework="portable40-net40+sl5+win8+wp8+wpa81" />
 			<group targetFramework="netstandard1.4">
-				<dependency id="System.Globalization.Calendars" version="4.0.1" />
+				<dependency id="System.Globalization" version="4.0.11" />
 				<dependency id="System.Linq" version="4.1.0" />
 				<dependency id="System.Reflection.TypeExtensions" version="4.1.0" />
 			</group>

--- a/PackageTesters/PackageTester.NET45/PackageTester.NET45.csproj
+++ b/PackageTesters/PackageTester.NET45/PackageTester.NET45.csproj
@@ -36,12 +36,12 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Flurl, Version=2.2.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Flurl.2.2.0\lib\portable40-net40+sl5+win8+wp8+wpa81\Flurl.dll</HintPath>
+    <Reference Include="Flurl, Version=2.2.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Flurl.2.2.1\lib\portable40-net40+sl5+win8+wp8+wpa81\Flurl.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Flurl.Http, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Flurl.Http.1.0.1\lib\net45\Flurl.Http.dll</HintPath>
+    <Reference Include="Flurl.Http, Version=1.0.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Flurl.Http.1.0.2\lib\net45\Flurl.Http.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Threading.Tasks, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/PackageTesters/PackageTester.NET45/packages.config
+++ b/PackageTesters/PackageTester.NET45/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Flurl" version="2.2.0" targetFramework="net45" />
-  <package id="Flurl.Http" version="1.0.1" targetFramework="net45" />
+  <package id="Flurl" version="2.2.1" targetFramework="net45" />
+  <package id="Flurl.Http" version="1.0.2" targetFramework="net45" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net45" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net45" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net45" />

--- a/PackageTesters/PackageTester.NET461/PackageTester.NET461.csproj
+++ b/PackageTesters/PackageTester.NET461/PackageTester.NET461.csproj
@@ -34,14 +34,15 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Flurl, Version=2.2.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Flurl.2.2.0\lib\netstandard1.4\Flurl.dll</HintPath>
+    <Reference Include="Flurl, Version=2.2.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Flurl.2.2.1\lib\netstandard1.4\Flurl.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Flurl.Http, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Flurl.Http.1.0.1\lib\net45\Flurl.Http.dll</HintPath>
+    <Reference Include="Flurl.Http, Version=1.0.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Flurl.Http.1.0.2\lib\net45\Flurl.Http.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.Win32.Primitives, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Win32.Primitives.4.0.1\lib\net46\Microsoft.Win32.Primitives.dll</HintPath>
       <Private>True</Private>
@@ -56,6 +57,10 @@
       <HintPath>..\..\packages\System.Diagnostics.DiagnosticSource.4.0.0\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.Globalization.Calendars, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Globalization.Calendars.4.0.1\lib\net46\System.Globalization.Calendars.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.IO.FileSystem, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.IO.FileSystem.4.0.1\lib\net46\System.IO.FileSystem.dll</HintPath>
       <Private>True</Private>
@@ -66,6 +71,10 @@
     </Reference>
     <Reference Include="System.Net.Http, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Net.Http.4.1.0\lib\net46\System.Net.Http.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Reflection.TypeExtensions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Reflection.TypeExtensions.4.1.0\lib\net46\System.Reflection.TypeExtensions.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Security.Cryptography.Algorithms, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/PackageTesters/PackageTester.NET461/packages.config
+++ b/PackageTesters/PackageTester.NET461/packages.config
@@ -1,13 +1,16 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Flurl" version="2.2.0" targetFramework="net461" />
-  <package id="Flurl.Http" version="1.0.1" targetFramework="net461" />
+  <package id="Flurl" version="2.2.1" targetFramework="net461" />
+  <package id="Flurl.Http" version="1.0.2" targetFramework="net461" />
   <package id="Microsoft.Win32.Primitives" version="4.0.1" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net461" />
   <package id="System.Diagnostics.DiagnosticSource" version="4.0.0" targetFramework="net461" />
+  <package id="System.Globalization.Calendars" version="4.0.1" targetFramework="net461" />
   <package id="System.IO.FileSystem" version="4.0.1" targetFramework="net461" />
   <package id="System.IO.FileSystem.Primitives" version="4.0.1" targetFramework="net461" />
+  <package id="System.Linq" version="4.1.0" targetFramework="net461" />
   <package id="System.Net.Http" version="4.1.0" targetFramework="net461" />
+  <package id="System.Reflection.TypeExtensions" version="4.1.0" targetFramework="net461" />
   <package id="System.Security.Cryptography.Algorithms" version="4.2.0" targetFramework="net461" />
   <package id="System.Security.Cryptography.Encoding" version="4.0.0" targetFramework="net461" />
   <package id="System.Security.Cryptography.Primitives" version="4.0.0" targetFramework="net461" />

--- a/PackageTesters/PackageTester.NETCore/project.json
+++ b/PackageTesters/PackageTester.NETCore/project.json
@@ -6,7 +6,7 @@
     }
   },
   "dependencies": {
-    "Flurl.Http": "1.0.1"
+    "Flurl.Http": "1.0.2"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/PackageTesters/PackageTester.PCL/PackageTester.PCL.csproj
+++ b/PackageTesters/PackageTester.PCL/PackageTester.PCL.csproj
@@ -49,12 +49,12 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Flurl, Version=2.2.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Flurl.2.2.0\lib\portable40-net40+sl5+win8+wp8+wpa81\Flurl.dll</HintPath>
+    <Reference Include="Flurl, Version=2.2.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Flurl.2.2.1\lib\portable40-net40+sl5+win8+wp8+wpa81\Flurl.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Flurl.Http, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Flurl.Http.1.0.1\lib\portable40-net45+sl5+win8+wp8+wpa81\Flurl.Http.dll</HintPath>
+    <Reference Include="Flurl.Http, Version=1.0.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Flurl.Http.1.0.2\lib\portable40-net45+sl5+win8+wp8+wpa81\Flurl.Http.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Threading.Tasks, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/PackageTesters/PackageTester.PCL/packages.config
+++ b/PackageTesters/PackageTester.PCL/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Flurl" version="2.2.0" targetFramework="portable40-net45+sl5+win8+wp8+wpa81" />
-  <package id="Flurl.Http" version="1.0.1" targetFramework="portable40-net45+sl5+win8+wp8+wpa81" />
+  <package id="Flurl" version="2.2.1" targetFramework="portable40-net45+sl5+win8+wp8+wpa81" />
+  <package id="Flurl.Http" version="1.0.2" targetFramework="portable40-net45+sl5+win8+wp8+wpa81" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="portable40-net45+sl5+win8+wp8+wpa81" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="portable40-net45+sl5+win8+wp8+wpa81" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="portable40-net45+sl5+win8+wp8+wpa81" />

--- a/PackageTesters/PackageTester.Shared/Tester.cs
+++ b/PackageTesters/PackageTester.Shared/Tester.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
+using Flurl;
 using Flurl.Http;
 using Flurl.Http.Testing;
 
@@ -17,9 +18,28 @@ namespace PackageTester
 				log("^-- fake response");
 			}
 
+			// Reproduce https://github.com/tmenier/Flurl/issues/128
+			using (var test = new HttpTest()) {
+				test.RespondWithJson(new TestResponse { TestString = "Test string" });
+
+				var response = new Url("http://www.google.com")
+				   .WithBasicAuth("test_username", "test_secret")
+				   .PostUrlEncodedAsync(new { test = "" })
+				   .ReceiveJson<TestResponse>()
+				   .Result;
+
+				log(response.TestString);
+				log("^-- fake response https://github.com/tmenier/Flurl/issues/128");
+			}
+
 			var path = await "http://www.google.com".DownloadFileAsync("c:\\", "google.txt");
 			log("dowloaded google source to " + path);
 			log("done");
 		}
+	}
+
+	internal class TestResponse
+	{
+		public string TestString { get; set; }
 	}
 }

--- a/Test/Flurl.Test.NETCore/project.json
+++ b/Test/Flurl.Test.NETCore/project.json
@@ -18,7 +18,7 @@
   },
 
   "dependencies": {
-    "dotnet-test-nunit": "3.4.0-beta-1",
+    "dotnet-test-nunit": "3.4.0-beta-2",
     "Flurl.Http": { "target": "project" },
     "NUnit": "3.4.1"
   },

--- a/src/Flurl.Http/project.json
+++ b/src/Flurl.Http/project.json
@@ -1,9 +1,9 @@
 {
   "title": "Flurl.Http",
-  "version": "1.0.1",
+  "version": "1.0.2",
 
   "dependencies": {
-    "Flurl": "2.2.0",
+    "Flurl": "2.2.1",
     "Newtonsoft.Json": "9.0.1"
   },
 

--- a/src/Flurl/project.json
+++ b/src/Flurl/project.json
@@ -1,6 +1,6 @@
 {
   "title": "Flurl",
-  "version": "2.2.0",
+  "version": "2.2.1",
 
   "buildOptions": {
     "compile": {

--- a/src/Flurl/project.json
+++ b/src/Flurl/project.json
@@ -28,7 +28,7 @@
     },
     "netstandard1.4": {
       "dependencies": {
-        "System.Globalization.Calendars": "4.0.1",
+        "System.Globalization": "4.0.11",
         "System.Linq": "4.1.0",
         "System.Reflection.TypeExtensions": "4.1.0"
       }


### PR DESCRIPTION
This fixed #128

- Added depencisies to Flurl NET461
- Added reproduce code to Tester

```c#
// Reproduce https://github.com/tmenier/Flurl/issues/128
			using (var test = new HttpTest()) {
				test.RespondWithJson(new TestResponse { TestString = "Test string" });

				var response = new Url("http://www.google.com")
				   .WithBasicAuth("test_username", "test_secret")
				   .PostUrlEncodedAsync(new { test = "" })
				   .ReceiveJson<TestResponse>()
				   .Result;

				log(response.TestString);
				log("^-- fake response https://github.com/tmenier/Flurl/issues/128");
			}
```

- Bump both versions