### PR TITLE
FlurlMessageHandler => RequestTimeout when OperationCanceledException. #159

### DIFF
--- a/Build/nuspec/Flurl.Http.nuspec
+++ b/Build/nuspec/Flurl.Http.nuspec
@@ -13,7 +13,7 @@
 			A fluent, portable, testable HTTP client library that extends Flurl's URL builder chain.
 		</description>
 		<releaseNotes>
-1.0.3 - Fix framework assemblies dependicies (https://github.com/tmenier/Flurl/issues/131)
+1.0.3 - .NET Core 1.0.1, fixed assembly references (github #131)
 1.0.2 - Updated Flurl dependency to 2.2.1 https://www.nuget.org/packages/Flurl/2.2.1   
 1.0.1 - Updated Flurl dependency to 2.2 https://www.nuget.org/packages/Flurl/2.2.0
 1.0.0 - Many updates and new features: https://github.com/tmenier/Flurl/releases/tag/Flurl.Http.1.0.0

--- a/src/Flurl.Http.Shared/Configuration/FlurlMessageHandler.cs
+++ b/src/Flurl.Http.Shared/Configuration/FlurlMessageHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
@@ -41,11 +42,12 @@ namespace Flurl.Http.Configuration
 				call.Exception = (cancellationToken.IsCancellationRequested) ?
 					new FlurlHttpException(call, ex) :
 					new FlurlHttpTimeoutException(call, ex);
-					call.Response = new HttpResponseMessage(HttpStatusCode.RequestTimeout);
+					call.Response = new HttpResponseMessage(HttpStatusCode.GatewayTimeout);
 			}
 			catch (Exception ex) {
 				call.Exception =  new FlurlHttpException(call, ex);
-			}
+                call.Response = new HttpResponseMessage(HttpStatusCode.ServiceUnavailable);
+            }
 
 			if (call.Response != null && !call.Succeeded) {
 				if (call.Response.Content != null)


### PR DESCRIPTION
Prevent FlurlMessageHandler return null HttpResponseMessage and OperationCanceledException is raised.