### PR TITLE
Add first-class support for query parameters without a value

### DIFF
--- a/Test/Flurl.Test.Shared/UrlBuilderTests.cs
+++ b/Test/Flurl.Test.Shared/UrlBuilderTests.cs
@@ -157,11 +157,13 @@ namespace Flurl.Test
 		[Test]
 		public void can_add_query_param_without_value()
 		{
-			var url = new Url("http://example.com?123456");
+		    string urlString = "http://example.com?123456";
+            var url = new Url(urlString);
 			Assert.AreEqual("http://example.com", url.Path);
 			Assert.AreEqual(1, url.QueryParams.Count);
-			Assert.AreEqual(string.Empty, url.QueryParams["123456"]);
-		}
+			Assert.AreEqual(true, url.QueryParams["123456"]);
+            Assert.AreEqual(urlString, url.ToString());
+        }
 
 		[Test]
 		public void can_change_query_param()

--- a/src/Flurl.Shared/QueryParamCollection.cs
+++ b/src/Flurl.Shared/QueryParamCollection.cs
@@ -40,10 +40,17 @@ namespace Flurl
 			Add(new QueryParameter(key, value, isEncoded));
 		}
 
-		/// <summary>
-		/// True if the collection contains a query parameter with the given name.
-		/// </summary>
-		public bool ContainsKey(string name) {
+        /// <summary>
+        /// Adds a new query parameter without a value.
+        /// </summary>
+        public void Add(string key) {
+            Add(new QueryParameter(key));
+        }
+
+        /// <summary>
+        /// True if the collection contains a query parameter with the given name.
+        /// </summary>
+        public bool ContainsKey(string name) {
 			return this.Any(p => p.Name == name);
 		}
 

--- a/src/Flurl.Shared/QueryParameter.cs
+++ b/src/Flurl.Shared/QueryParameter.cs
@@ -13,6 +13,7 @@ namespace Flurl
 	{
 		private object _value;
 		private string _encodedValue;
+	    private readonly bool _isWithoutValue = false;
 
 		/// <summary>
 		/// Creates a new instance of a query parameter.
@@ -37,17 +38,26 @@ namespace Flurl
 			}
 		}
 
-		/// <summary>
-		/// The name (left side) of the query parameter.
-		/// </summary>
-		public string Name { get; set; }
+        /// <summary>
+        /// Creates a new instance of a query parameter without a value.
+        /// </summary>
+        public QueryParameter(string name) {
+            Name = name;
+            Value = "";
+            _isWithoutValue = true;
+        }
+
+        /// <summary>
+        /// The name (left side) of the query parameter.
+        /// </summary>
+        public string Name { get; set; }
 
 		/// <summary>
 		/// The value (right side) of the query parameter.
 		/// </summary>
 		public object Value
-		{
-			get { return _value; }
+        {
+			get { return _isWithoutValue ? true : _value; }
 			set
 			{
 				_value = value;
@@ -61,13 +71,16 @@ namespace Flurl
 		/// <param name="encodeSpaceAsPlus">Indicates whether to encode space characters with "+" instead of "%20".</param>
 		/// <returns></returns>
 		public string ToString(bool encodeSpaceAsPlus) {
-			if (Value is IEnumerable && !(Value is string)) {
-				return string.Join("&",
-					from v in (Value as IEnumerable).Cast<object>()
-					where v != null
-					let encoded = Url.EncodeQueryParamValue(v, encodeSpaceAsPlus)
-					select $"{Name}={encoded}");
-			}
+		    if (Value is IEnumerable && !(Value is string)) {
+		        return string.Join("&",
+		            from v in (Value as IEnumerable).Cast<object>()
+		            where v != null
+		            let encoded = Url.EncodeQueryParamValue(v, encodeSpaceAsPlus)
+		            select $"{Name}={encoded}");
+		    }
+		    else if (_isWithoutValue) {
+		        return $"{Name}";
+		    }
 			else {
 				var encoded = _encodedValue ?? Url.EncodeQueryParamValue(_value, encodeSpaceAsPlus);
 				return $"{Name}={encoded}";

--- a/src/Flurl.Shared/StringExtensions.cs
+++ b/src/Flurl.Shared/StringExtensions.cs
@@ -57,17 +57,30 @@ namespace Flurl
 			return new Url(url).SetQueryParam(name, value);
 		}
 
-		/// <summary>
-		/// Creates a new Url object from the string and adds a parameter to the query, overwriting the value if name exists.
-		/// </summary>
-		/// <param name="url">The URL.</param>
-		/// <param name="name">Name of query parameter</param>
-		/// <param name="value">Value of query parameter</param>
-		/// <param name="isEncoded">Set to true to indicate the value is already URL-encoded (typically false)</param>
-		/// <returns>
-		/// The Url object with the query parameter added
-		/// </returns>
-		public static Url SetQueryParam(this string url, string name, string value, bool isEncoded) {
+        /// <summary>
+        /// Creates a new Url object from the string and adds a parameter without a value to the query.
+        /// </summary>
+        /// <param name="url">The URL.</param>
+        /// <param name="name">name of query parameter</param>
+        /// <returns>
+        /// The Url object with the query parameter added
+        /// </returns>
+        public static Url SetQueryParam(this string url, string name)
+        {
+            return new Url(url).SetQueryParam(name);
+        }
+
+        /// <summary>
+        /// Creates a new Url object from the string and adds a parameter to the query, overwriting the value if name exists.
+        /// </summary>
+        /// <param name="url">The URL.</param>
+        /// <param name="name">Name of query parameter</param>
+        /// <param name="value">Value of query parameter</param>
+        /// <param name="isEncoded">Set to true to indicate the value is already URL-encoded (typically false)</param>
+        /// <returns>
+        /// The Url object with the query parameter added
+        /// </returns>
+        public static Url SetQueryParam(this string url, string name, string value, bool isEncoded) {
 			return new Url(url).SetQueryParam(name, value, isEncoded);
 		}
 

--- a/src/Flurl.Shared/Url.cs
+++ b/src/Flurl.Shared/Url.cs
@@ -65,7 +65,7 @@ namespace Flurl
 				let pair = p.SplitOnFirstOccurence('=')
 				let name = pair[0]
 				let value = (pair.Length == 1) ? "" : pair[1]
-				select new QueryParameter(name, value, true));
+				select value == "" ? new QueryParameter(name) : new QueryParameter(name, value, true));
 
 			return result;
 		}
@@ -208,15 +208,29 @@ namespace Flurl
 			return this;
 		}
 
-	    /// <summary>
-	    /// Adds a parameter to the query, overwriting the value if name exists.
-	    /// </summary>
-	    /// <param name="name">Name of query parameter</param>
-	    /// <param name="value">Value of query parameter</param>
-	    /// <param name="isEncoded">Set to true to indicate the value is already URL-encoded (typically false)</param>
-	    /// <returns>The Url object with the query parameter added</returns>
-	    /// <exception cref="ArgumentNullException"><paramref name="name"/> is <see langword="null" />.</exception>
-	    public Url SetQueryParam(string name, string value, bool isEncoded) {
+        /// <summary>
+        /// Adds a parameter without a value to the query.
+        /// </summary>
+        /// <param name="name">Name of query parameter</param>
+        /// <returns>The Url object with the query parameter added</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="name"/> is <see langword="null" />.</exception>
+        public Url SetQueryParam(string name) {
+            if (name == null)
+                throw new ArgumentNullException(nameof(name), "Query parameter name cannot be null.");
+
+            QueryParams.Add(name);
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a parameter to the query, overwriting the value if name exists.
+        /// </summary>
+        /// <param name="name">Name of query parameter</param>
+        /// <param name="value">Value of query parameter</param>
+        /// <param name="isEncoded">Set to true to indicate the value is already URL-encoded (typically false)</param>
+        /// <returns>The Url object with the query parameter added</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="name"/> is <see langword="null" />.</exception>
+        public Url SetQueryParam(string name, string value, bool isEncoded) {
 			if (name == null)
 				throw new ArgumentNullException(nameof(name), "Query parameter name cannot be null.");
 


### PR DESCRIPTION
Fixes https://github.com/tmenier/Flurl/issues/164

Note that the implicit value of a query parameter without a value in this PR is (bool) true.