### PR TITLE
Use round-trip format specifier for DateTime

### DIFF
--- a/src/Flurl/Util/CommonExtensions.cs
+++ b/src/Flurl/Util/CommonExtensions.cs
@@ -37,6 +37,10 @@ namespace Flurl.Util
 		/// </summary>
 		public static string ToInvariantString(this object obj) {
 			// inspired by: http://stackoverflow.com/a/19570016/62600
+				
+			var d = obj as DateTime?;
+			if (d != null)
+				return d.Value.ToString("O", CultureInfo.InvariantCulture);
 
 #if !NETSTANDARD1_0
 			var c = obj as IConvertible;


### PR DESCRIPTION
The default format for DateTime.ToString(CultureInfo.InvariantCulture) seems to be MM/dd/yyyy HH:mm:ss which is not appropriate for serialization purposes. Using the "round-trip" format specifier emits a result string that complies with ISO 8601 and preserves time zone information and DateTime.Kind.