### PR TITLE
TestFlurlClientFactory exception fix

### DIFF
--- a/Test/Flurl.Test/Http/FlurlClientFactoryTests.cs
+++ b/Test/Flurl.Test/Http/FlurlClientFactoryTests.cs
@@ -1,0 +1,67 @@
+﻿using System.Threading.Tasks;
+using Flurl.Http;
+using Flurl.Http.Configuration;
+using Flurl.Http.Testing;
+using NUnit.Framework;
+
+namespace Flurl.Test.Http
+{
+    [TestFixture, Parallelizable]
+    public class FlurlClientFactoryTests
+    {
+        private HttpTest httpTest;
+        private readonly IFlurlClientFactory flurlClientFactory;
+        private readonly FlurlClientFactoryTestService testService;
+
+        public FlurlClientFactoryTests()
+        {
+            flurlClientFactory = new TestFlurlClientFactory();
+            testService = new FlurlClientFactoryTestService(flurlClientFactory);
+        }
+
+        [SetUp]
+        public void Setup()
+        {
+            httpTest = new HttpTest();
+        }
+
+        [TearDown]
+        public void Cleanup()
+        {
+            httpTest.Dispose();
+        }
+
+        [Test]
+        public async Task can_make_requests_using_flurlclientfactory()
+        {
+            var actual = await testService.MakeCall();
+
+            httpTest.ShouldHaveCalled("http://fake-domain.com:8080/some/fake/path")
+                .WithRequestJson(new
+                {
+                    Data = "some data"
+                });
+        }
+    }
+
+    internal class FlurlClientFactoryTestService
+    {
+        private readonly IFlurlClient _client;
+
+        public FlurlClientFactoryTestService(IFlurlClientFactory clientFactory)
+        {
+            _client = clientFactory.Get("http://fake-domain.com:8080/")
+                .WithHeader("Content-type", "application/json");
+        }
+
+        public Task<object> MakeCall()
+        {
+            return _client.Request("/some/fake/path")
+                .PostJsonAsync(new
+                {
+                    Data = "some data"
+                })
+                .ReceiveJson<object>();
+        }
+    }
+}

--- a/Test/Flurl.Test/Http/FlurlClientFactoryTests.cs
+++ b/Test/Flurl.Test/Http/FlurlClientFactoryTests.cs
@@ -7,9 +7,8 @@ using NUnit.Framework;
 namespace Flurl.Test.Http
 {
     [TestFixture, Parallelizable]
-    public class FlurlClientFactoryTests
+    public class FlurlClientFactoryTests: HttpTestFixtureBase
     {
-        private HttpTest httpTest;
         private readonly IFlurlClientFactory flurlClientFactory;
         private readonly FlurlClientFactoryTestService testService;
 
@@ -19,24 +18,12 @@ namespace Flurl.Test.Http
             testService = new FlurlClientFactoryTestService(flurlClientFactory);
         }
 
-        [SetUp]
-        public void Setup()
-        {
-            httpTest = new HttpTest();
-        }
-
-        [TearDown]
-        public void Cleanup()
-        {
-            httpTest.Dispose();
-        }
-
         [Test]
-        public async Task can_make_requests_using_flurlclientfactory()
+        public async Task can_make_post_requests_using_flurlclientfactory()
         {
             var actual = await testService.MakeCall();
 
-            httpTest.ShouldHaveCalled("http://fake-domain.com:8080/some/fake/path")
+            HttpTest.ShouldHaveCalled("http://fake-domain.com:8080/some/fake/path")
                 .WithRequestJson(new
                 {
                     Data = "some data"

--- a/src/Flurl.Http/Testing/TestFactories.cs
+++ b/src/Flurl.Http/Testing/TestFactories.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Net.Http;
+﻿using System.Net.Http;
 using Flurl.Http.Configuration;
 
 namespace Flurl.Http.Testing
@@ -23,15 +22,13 @@ namespace Flurl.Http.Testing
 	/// </summary>
 	public class TestFlurlClientFactory : FlurlClientFactoryBase
 	{
-		private readonly Lazy<FlurlClient> _client = new Lazy<FlurlClient>(() => new FlurlClient());
-
 		/// <summary>
 		/// Returns the FlurlClient sigleton used for testing
 		/// </summary>
 		/// <param name="url">The URL.</param>
 		/// <returns>The FlurlClient instance.</returns>
 		public override IFlurlClient Get(Url url) {
-			return _client.Value;
+			return new FlurlClient(url.ToString());
 		}
 
 		/// <summary>

--- a/src/Flurl.Http/Testing/TestFactories.cs
+++ b/src/Flurl.Http/Testing/TestFactories.cs
@@ -1,4 +1,5 @@
-﻿using System.Net.Http;
+﻿using System;
+using System.Net.Http;
 using Flurl.Http.Configuration;
 
 namespace Flurl.Http.Testing


### PR DESCRIPTION
When making a call to a service that mocks the ```IFlurlClientFactory``` dependency using the class ```TestFlurlClientFactory```, an exception is thrown saying:
```
Cannot create a Request. BaseUrl is not defined and no segments were passed.
```