### PR TITLE
Test Assertion WithContentType no longer throws NullReferenceException if no content was sent

### DIFF
--- a/Test/Flurl.Test/Http/TestingTests.cs
+++ b/Test/Flurl.Test/Http/TestingTests.cs
@@ -215,6 +215,16 @@ namespace Flurl.Test.Http
 				CallAndAssertCountAsync(6));
 		}
 
+		[Test]
+		public async Task does_not_throw_nullref_for_empty_content() {
+			await "http://some-api.com".AppendPathSegment("foo").SendAsync(HttpMethod.Post, null);
+			await "http://some-api.com".AppendPathSegment("foo").PostJsonAsync(new { foo = "bar" });
+
+			HttpTest.ShouldHaveCalled("http://some-api.com/foo")
+				.WithVerb(HttpMethod.Post)
+				.WithContentType("application/json");
+		}
+
 		private async Task CallAndAssertCountAsync(int calls) {
 			using (var test = new HttpTest()) {
 				for (int i = 0; i < calls; i++) {

--- a/src/Flurl.Http/Testing/HttpCallAssertion.cs
+++ b/src/Flurl.Http/Testing/HttpCallAssertion.cs
@@ -189,7 +189,7 @@ namespace Flurl.Http.Testing
 		/// </summary>
 		public HttpCallAssertion WithContentType(string mediaType) {
 			_expectedConditions.Add("content type " + mediaType);
-			return With(c => c.Request.Content.Headers.ContentType.MediaType == mediaType);
+			return With(c => c.Request.Content?.Headers?.ContentType?.MediaType == mediaType);
 		}
 
 		/// <summary>


### PR DESCRIPTION
If a some requests were made to a URL containing the same part where some requests included content and some did not, attempting to assert that the client ShouldHaveCalled that part with a post and a contnet type would throw a NullReferenceException when it encountered the requests that did not have any content sent with them. Ignore requests with no content when asserting on ContentType.

Fixes #285 

The test I wrote fails without these changes and passes with them. I can't verify that this doesn't break other things as there are other test failures due to line endings and path separators being windows-specific (see #286) but I'm 99.9% certain that this should not break anything.