### PR TITLE
Strictly match URLs if no wildcard is present in the string

### DIFF
--- a/Test/Flurl.Test/Http/TestingTests.cs
+++ b/Test/Flurl.Test/Http/TestingTests.cs
@@ -19,6 +19,7 @@ namespace Flurl.Test.Http
 	            .GetAsync();
 
 	        HttpTest.ShouldHaveMadeACall().WithUrlPattern("http://api.com/test");
+	        HttpTest.ShouldHaveMadeACall().WithUrlPattern("http://api.com/TEST");
 
 	        Assert.Throws<HttpCallAssertException>(() =>
 	                HttpTest.ShouldHaveMadeACall().WithUrlPattern("http://api.com"));

--- a/Test/Flurl.Test/Http/TestingTests.cs
+++ b/Test/Flurl.Test/Http/TestingTests.cs
@@ -20,9 +20,12 @@ namespace Flurl.Test.Http
 
 	        HttpTest.ShouldHaveMadeACall().WithUrlPattern("http://api.com/test");
 	        HttpTest.ShouldHaveMadeACall().WithUrlPattern("http://api.com/TEST");
+	        HttpTest.ShouldHaveMadeACall().WithUrlPattern("http://api.com/*");
 
 	        Assert.Throws<HttpCallAssertException>(() =>
 	                HttpTest.ShouldHaveMadeACall().WithUrlPattern("http://api.com"));
+	        Assert.Throws<HttpCallAssertException>(() =>
+	            HttpTest.ShouldHaveMadeACall().WithUrlPattern("http://api.com/*/a"));
 	    }
 
 		[Test]

--- a/Test/Flurl.Test/Http/TestingTests.cs
+++ b/Test/Flurl.Test/Http/TestingTests.cs
@@ -12,6 +12,18 @@ namespace Flurl.Test.Http
 	[TestFixture, Parallelizable]
 	public class TestingTests : HttpTestFixtureBase
 	{
+	    [Test]
+	    public async Task can_assert_url() {
+	        await "http://api.com"
+	            .AppendPathSegment("test")
+	            .GetAsync();
+
+	        HttpTest.ShouldHaveMadeACall().WithUrlPattern("http://api.com/test");
+
+	        Assert.Throws<HttpCallAssertException>(() =>
+	                HttpTest.ShouldHaveMadeACall().WithUrlPattern("http://api.com"));
+	    }
+
 		[Test]
 		public async Task fake_get_works() {
 			HttpTest.RespondWith("great job");

--- a/src/Flurl.Http/Testing/HttpCallAssertion.cs
+++ b/src/Flurl.Http/Testing/HttpCallAssertion.cs
@@ -54,7 +54,7 @@ namespace Flurl.Http.Testing
             // if no wildcard is present do a strict match
             // https://github.com/tmenier/Flurl/issues/323
 		    if (!urlPattern.Contains("*"))
-		        return With(c => c.FlurlRequest.Url == urlPattern);
+		        return With(c => string.Equals(c.FlurlRequest.Url,urlPattern, StringComparison.OrdinalIgnoreCase));
 
 			_expectedConditions.Add($"URL pattern {urlPattern}");
 			return With(c => MatchesPattern(c.FlurlRequest.Url, urlPattern));

--- a/src/Flurl.Http/Testing/HttpCallAssertion.cs
+++ b/src/Flurl.Http/Testing/HttpCallAssertion.cs
@@ -50,6 +50,12 @@ namespace Flurl.Http.Testing
 				Assert();
 				return this;
 			}
+
+            // if no wildcard is present do a strict match
+            // https://github.com/tmenier/Flurl/issues/323
+		    if (!urlPattern.Contains("*"))
+		        return With(c => c.FlurlRequest.Url == urlPattern);
+
 			_expectedConditions.Add($"URL pattern {urlPattern}");
 			return With(c => MatchesPattern(c.FlurlRequest.Url, urlPattern));
 		}


### PR DESCRIPTION
#323 

Do a simple case ignoring string equality comparison if wildcard is not in the string