### PR TITLE
HttpTest use AsyncLocal like NetStandard in NetFramework 4.6 and later

### DIFF
--- a/src/Flurl.Http/Flurl.Http.csproj
+++ b/src/Flurl.Http/Flurl.Http.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;netstandard1.1;netstandard1.3;netstandard2.0;</TargetFrameworks>
+    <TargetFrameworks>net45;net46;netstandard1.1;netstandard1.3;netstandard2.0;</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard1.1;netstandard1.3;netstandard2.0;</TargetFrameworks>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 	  <PackageId>Flurl.Http</PackageId>
@@ -53,6 +53,10 @@
   </PropertyGroup>
   
   <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
+    <Reference Include="System.Net.Http" />
+  </ItemGroup>
+    
+  <ItemGroup Condition="'$(TargetFramework)' == 'net46'">
     <Reference Include="System.Net.Http" />
   </ItemGroup>
 

--- a/src/Flurl.Http/Testing/HttpTest.cs
+++ b/src/Flurl.Http/Testing/HttpTest.cs
@@ -13,8 +13,8 @@ namespace Flurl.Http.Testing
 	/// An object whose existence puts Flurl.Http into test mode where actual HTTP calls are faked. Provides a response
 	/// queue, call log, and assertion helpers for use in Arrange/Act/Assert style tests.
 	/// </summary>
-#if !NETSTANDARD1_1
-	[Serializable] // fixes MSTest issue? #207
+#if NET45
+	[Serializable]
 #endif
 	public class HttpTest : IDisposable
 	{
@@ -174,7 +174,7 @@ namespace Flurl.Http.Testing
 #if NET45
 		private static void SetCurrentTest(HttpTest test) => System.Runtime.Remoting.Messaging.CallContext.LogicalSetData("FlurlHttpTest", test);
 		private static HttpTest GetCurrentTest() => System.Runtime.Remoting.Messaging.CallContext.LogicalGetData("FlurlHttpTest") as HttpTest;
-#elif NETSTANDARD1_3 || NETSTANDARD2_0
+#elif NET46 || NETSTANDARD1_3 || NETSTANDARD2_0
 		private static System.Threading.AsyncLocal<HttpTest> _test = new System.Threading.AsyncLocal<HttpTest>();
 		private static void SetCurrentTest(HttpTest test) => _test.Value = test;
 		private static HttpTest GetCurrentTest() => _test.Value;


### PR DESCRIPTION
Hi,

The HttpTest is stored in a CallContext ([here](https://github.com/tmenier/Flurl/blob/d6bb8cb7f9a26717d85ca0c48d4acfb895237b35/src/Flurl.Http/Testing/HttpTest.cs#L175)) for the .NetFramework version of the library.
From the documentation, the object passed to the [LogicalSetData](https://docs.microsoft.com/en-us/dotnet/api/system.runtime.remoting.messaging.callcontext.logicalsetdata?view=netframework-4.7.1) method need to be serializable.
It's because the CallContext content is serialized between AppDomain by a BinaryFormatter.
The [BinaryFormatter](https://docs.microsoft.com/en-us/dotnet/api/system.runtime.serialization.formatters.binary.binaryformatter.serialize?view=netframework-4.7.1) need the complete object graph to be able to serialize the object, it's not the case for the HttpTest class.
As long as the context content is not passed to another AppDomain and that the serialization dont occur no problem, but when it's the case an SerializationException is raised.

I'm having this issue when executing the XUnit tests in Resharper Test Runner  with coverage enabled.

So the solution is to use the same api introduce in .NetStandard : [AsyncLocal](https://docs.microsoft.com/en-us/dotnet/api/system.threading.asynclocal-1?view=netframework-4.7.1).

But the AsyncLocal is only  available from .NetFramework 4.6, so I had also to add Net46 target to the TargetFrameworks.