### PR TITLE
"Multipart/form-data" format change.

### DIFF
--- a/Test/Flurl.Test/Http/MultipartTests.cs
+++ b/Test/Flurl.Test/Http/MultipartTests.cs
@@ -25,27 +25,27 @@ namespace Flurl.Test.Http
 
 			Assert.AreEqual(6, content.Parts.Length);
 
-			Assert.AreEqual("string", content.Parts[0].Headers.ContentDisposition.Name);
+			Assert.AreEqual("string", content.Parts[0].Headers.ContentDisposition.Name.Trim('"'));
 			Assert.IsInstanceOf<CapturedStringContent>(content.Parts[0]);
 			Assert.AreEqual("foo", (content.Parts[0] as CapturedStringContent).Content);
 
-			Assert.AreEqual("part1", content.Parts[1].Headers.ContentDisposition.Name);
+			Assert.AreEqual("part1", content.Parts[1].Headers.ContentDisposition.Name.Trim('"'));
 			Assert.IsInstanceOf<CapturedStringContent>(content.Parts[1]);
 			Assert.AreEqual("1", (content.Parts[1] as CapturedStringContent).Content);
 
-			Assert.AreEqual("part2", content.Parts[2].Headers.ContentDisposition.Name);
+			Assert.AreEqual("part2", content.Parts[2].Headers.ContentDisposition.Name.Trim('"'));
 			Assert.IsInstanceOf<CapturedStringContent>(content.Parts[2]);
 			Assert.AreEqual("2", (content.Parts[2] as CapturedStringContent).Content);
 
-			Assert.AreEqual("file", content.Parts[3].Headers.ContentDisposition.Name);
-			Assert.AreEqual("image.jpg", content.Parts[3].Headers.ContentDisposition.FileName);
+			Assert.AreEqual("file", content.Parts[3].Headers.ContentDisposition.Name.Trim('"'));
+			Assert.AreEqual("image.jpg", content.Parts[3].Headers.ContentDisposition.FileName.Trim('"'));
 			Assert.IsInstanceOf<FileContent>(content.Parts[3]);
 
-			Assert.AreEqual("json", content.Parts[4].Headers.ContentDisposition.Name);
+			Assert.AreEqual("json", content.Parts[4].Headers.ContentDisposition.Name.Trim('"'));
 			Assert.IsInstanceOf<CapturedJsonContent>(content.Parts[4]);
 			Assert.AreEqual("{\"foo\":\"bar\"}", (content.Parts[4] as CapturedJsonContent).Content);
 
-			Assert.AreEqual("urlEnc", content.Parts[5].Headers.ContentDisposition.Name);
+			Assert.AreEqual("urlEnc", content.Parts[5].Headers.ContentDisposition.Name.Trim('"'));
 			Assert.IsInstanceOf<CapturedUrlEncodedContent>(content.Parts[5]);
 			Assert.AreEqual("fizz=buzz", (content.Parts[5] as CapturedUrlEncodedContent).Content);
 		}

--- a/src/Flurl.Http/Content/CapturedMultipartContent.cs
+++ b/src/Flurl.Http/Content/CapturedMultipartContent.cs
@@ -124,9 +124,9 @@ namespace Flurl.Http.Content
 				throw new ArgumentException("name must not be empty", nameof(name));
 
 			content.Headers.ContentDisposition = new ContentDispositionHeaderValue("form-data") {
-				Name = name,
-				FileName = fileName,
-				FileNameStar = fileName
+                Name = '"' + name + '"',
+                FileName = (fileName == null ? null : ('"' + fileName + '"')),
+                FileNameStar = fileName
 			};
 			base.Add(content);
 			return this;


### PR DESCRIPTION
Sorry, my English is not very good. The following content is from "https://translate.google.cn" and I hope you can understand what I mean.
I used the 'Fiddler' capture tool to get the 'Flurl' uploaded content, which is similar to this:

`Content-Disposition: form-data; name=file;`

According to the protocol of '[RFC1867](http://www.ietf.org/rfc/rfc1867)', it should look like this:

`Content-Disposition: form-data; name="file";`

This bug occurs in ASP.NET WebSite in Framework 2.0. The file server does not get any parameters. `HttpContext.Current.Request.Files.Count=0`，Although few developers now use such an ancient framework, I hope Flurl will be compatible with it.

thx.