### PR TITLE
Introduce support for nested objects

### DIFF
--- a/Test/Flurl.Test/CommonExtensionsTests.cs
+++ b/Test/Flurl.Test/CommonExtensionsTests.cs
@@ -26,6 +26,18 @@ namespace Flurl.Test
 		}
 
 		[Test]
+		public void can_parse_nested_object_to_kv() {
+			var kv = new {
+				one = new { two = "foo", three = new { four = "bar"}},
+			}.ToKeyValuePairs();
+
+			CollectionAssert.AreEquivalent(new Dictionary<string, object> {
+				{ "one.two", "foo" },
+				{ "one.three.four", "bar" },
+			}, kv);
+		}
+
+		[Test]
 		public void can_parse_dictionary_to_kv()
 		{
 			var kv = new Dictionary<string, object> {
@@ -88,6 +100,16 @@ namespace Flurl.Test
 				{ "one", "1" },
 				{ "two", "foo" },
 				{ "three", null }
+			}, kv);
+		}
+
+		[Test]
+		public void can_parse_string_with_nested_objects_to_kv() {
+			var kv = "one.two=foo&one.three.four=bar".ToKeyValuePairs();
+
+			CollectionAssert.AreEquivalent(new Dictionary<string, object> {
+				{ "one.two", "foo" },
+				{ "one.three.four", "bar" }
 			}, kv);
 		}
 

--- a/Test/Flurl.Test/Http/RealHttpTests.cs
+++ b/Test/Flurl.Test/Http/RealHttpTests.cs
@@ -270,7 +270,7 @@ namespace Flurl.Test.Http
 				cts.Cancel();
 				await task;
 			});
-			Assert.That(ex.InnerException is TaskCanceledException);
+			Assert.That(ex.InnerException is OperationCanceledException);
 			Assert.IsTrue(cts.Token.IsCancellationRequested);
 
 			// timeout with cancellation token set
@@ -280,7 +280,7 @@ namespace Flurl.Test.Http
 					.WithTimeout(TimeSpan.FromMilliseconds(50))
 					.GetAsync(cts.Token);
 			});
-			Assert.That(ex.InnerException is TaskCanceledException);
+			Assert.That(ex.InnerException is OperationCanceledException);
 			Assert.IsFalse(cts.Token.IsCancellationRequested);
 		}
 

--- a/Test/Flurl.Test/UrlBuilderTests.cs
+++ b/Test/Flurl.Test/UrlBuilderTests.cs
@@ -514,5 +514,25 @@ namespace Flurl.Test
 			Assert.AreEqual("http://mysite.com?x=1&z=3", url1.ToString());
 			Assert.AreEqual("http://mysite.com/foo?x=1&y=2", url2.ToString());
 		}
+
+		[Test]
+		public void set_query_params_can_parse_nested_object() {
+			var url = "http://www.mysite.com".SetQueryParams(new {
+				x = 1,
+				y = 2,
+				z = new { a = 3, b = 4 }
+			});
+			Assert.AreEqual("http://www.mysite.com?x=1&y=2&z.a=3&z.b=4", url.ToString());
+		}
+
+		[Test]
+		public void set_query_params_can_parse_second_level_nested_objects() {
+			var url = "http://www.mysite.com".SetQueryParams(new {
+				x = 1,
+				y = 2,
+				z = new { a = new { b = 3 } }
+			});
+			Assert.AreEqual("http://www.mysite.com?x=1&y=2&z.a.b=3", url.ToString());
+		}
 	}
 }

--- a/src/Flurl/Util/CommonExtensions.cs
+++ b/src/Flurl/Util/CommonExtensions.cs
@@ -107,7 +107,7 @@ namespace Flurl.Util
 		}
 
 		// Credits to Stefan Steinegger, https://stackoverflow.com/a/863944/2001970
-		public static bool IsSimple(this Type type) {
+		private static bool IsSimple(this Type type) {
 #if NET40
 			if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>)) {
 				// nullable type, check if the nested type is simple.


### PR DESCRIPTION
At work, we encountered a case where we have contract classes (DTOs) containing another DTOs, being nested objects. It seemed that Flurl doesn't support this currently, while e.g. ASP.NET MVC model binder can correctly deserialize them from GET query parameters. 

Hence the PR, introducing support for serializing nested object by composing property names using a dot.

By the way, I modified `can_set_timeout_and_cancellation_token` test to expect `OperationCancelledException` instead of `TaskCancelledException`, because it simply wouldn't pass on my machine otherwise. I'm not entirely sure that's correct, but it seems reasonable since `OperationCancelledException` is a base class and also represents cancellation.