### PR TITLE
Add support for deserialize to type

### DIFF
--- a/Test/Flurl.Test/Http/DeserializationTests.cs
+++ b/Test/Flurl.Test/Http/DeserializationTests.cs
@@ -1,0 +1,53 @@
+﻿using Flurl.Http.Configuration;
+using NUnit.Framework;
+
+namespace Flurl.Test.Http
+{
+	[TestFixture, Parallelizable]
+	public class DeserializationTests : HttpTestFixtureBase
+	{
+		[Test]
+		public void can_be_deserialize_int_generic() {
+			var serializer = new NewtonsoftJsonSerializer(null);
+			var result = serializer.Deserialize<int>("1");
+			Assert.IsNotNull(result);
+			Assert.AreEqual(1, result);
+		}
+
+		[Test]
+		public void can_be_deserialize_int_type() {
+			var serializer = new NewtonsoftJsonSerializer(null);
+			var result = serializer.Deserialize("1", typeof(int));
+			Assert.IsNotNull(result);
+			Assert.AreEqual(typeof(int), result.GetType());
+			Assert.AreEqual(1, result);
+		}
+
+		[Test]
+		public void can_be_deserialize_testdata_object_generic() {
+			var serializer = new NewtonsoftJsonSerializer(null);
+			var result = serializer.Deserialize<TestData>("{id: 1, name:\"jon\"}");
+			Assert.IsNotNull(result);
+			Assert.AreEqual(1, result.id);
+			Assert.AreEqual("jon", result.name);
+		}
+
+		[Test]
+		public void can_be_deserialize_testdata_object_type() {
+			var serializer = new NewtonsoftJsonSerializer(null);
+			var result = serializer.Deserialize("{id: 1, name:\"jon\"}", typeof(TestData));
+			Assert.IsNotNull(result);
+			Assert.AreEqual(typeof(TestData), result.GetType());
+
+			var resultTestdata = (TestData)result;
+			Assert.AreEqual(1, resultTestdata.id);
+			Assert.AreEqual("jon", resultTestdata.name);
+		}
+
+		private class TestData
+		{
+			public int id { get; set; }
+			public string name { get; set; }
+		}
+	}
+}

--- a/Test/Flurl.Test/Http/GetTests.cs
+++ b/Test/Flurl.Test/Http/GetTests.cs
@@ -112,6 +112,26 @@ namespace Flurl.Test.Http
 		}
 
 		[Test]
+		public async Task can_get_error_json_as_object() {
+			HttpTest.RespondWithJson(new { code = 999, message = "our server crashed" }, 500);
+
+			try {
+				await "http://api.com".GetStringAsync();
+			}
+			catch (FlurlHttpException ex) {
+				var error = await ex.GetResponseJsonAsync(typeof(TestError));
+
+				Assert.IsNotNull(error);
+				Assert.AreEqual(typeof(TestError), error.GetType());
+
+				var errordata = (TestError)error;
+				
+				Assert.AreEqual(999, errordata.code);
+				Assert.AreEqual("our server crashed", errordata.message);
+			}
+		}
+
+		[Test]
 		public async Task can_get_error_json_untyped() {
 			HttpTest.RespondWithJson(new { code = 999, message = "our server crashed" }, 500);
 

--- a/Test/Flurl.Test/Http/PostTests.cs
+++ b/Test/Flurl.Test/Http/PostTests.cs
@@ -57,6 +57,23 @@ namespace Flurl.Test.Http
 			Assert.AreEqual("Frank", data.name);
 		}
 
+
+		[Test]
+		public async Task can_receive_json_object() {
+			HttpTest.RespondWithJson(new { id = 1, name = "Frank" });
+
+			var data = await "http://some-api.com".PostJsonAsync(new { a = 1, b = 2 }).ReceiveJson(typeof(TestData));
+
+			Assert.IsNotNull(data);
+			Assert.AreEqual(data.GetType(), typeof(TestData));
+
+			var testdata = (TestData)data;
+
+			Assert.AreEqual(1, testdata.id);
+			Assert.AreEqual("Frank", testdata.name);
+		}
+
+
 		[Test]
 		public async Task can_receive_json_dynamic() {
 			HttpTest.RespondWithJson(new { id = 1, name = "Frank" });

--- a/Test/Flurl.Test/Http/SettingsTests.cs
+++ b/Test/Flurl.Test/Http/SettingsTests.cs
@@ -246,6 +246,8 @@ namespace Flurl.Test.Http
 			public string Serialize(object obj) => "foo";
 			public T Deserialize<T>(string s) => default(T);
 			public T Deserialize<T>(Stream stream) => default(T);
+			public object Deserialize(string s, Type type) => default(object);
+			public object Deserialize(Stream stream, Type type) => default(object);
 		}
 	}
 

--- a/src/Flurl.Http.CodeGen/HttpExtensionMethod.cs
+++ b/src/Flurl.Http.CodeGen/HttpExtensionMethod.cs
@@ -15,12 +15,15 @@ namespace Flurl.Http.CodeGen
 				where httpVerb == "Get" || respType == null
 				from isGeneric in new[] { true, false }
 				where AllowDeserializeToGeneric(respType) || !isGeneric
+				from withType in new[] { true, false }
+				where (AllowDeserializeToGeneric(respType) && !isGeneric) || !withType
 				select new HttpExtensionMethod {
 					HttpVerb = httpVerb,
 					RequestBodyType = reqType,
 					ExtentionOfType = extensionType,
 					ResponseBodyType = respType,
-					IsGeneric = isGeneric
+					IsGeneric = isGeneric,
+					WithType = withType
 				};
 		}
 
@@ -52,13 +55,14 @@ namespace Flurl.Http.CodeGen
 		public string ExtentionOfType { get; set; }
 		public string ResponseBodyType { get; set; }
 		public bool IsGeneric { get; set; }
+		public bool WithType { get; set; }
 
 		public string Name => $"{HttpVerb ?? "Send"}{RequestBodyType ?? ResponseBodyType}Async";
 
 		public string TaskArg {
 			get {
 				switch (ResponseBodyType) {
-					case "Json": return IsGeneric ? "T" : "dynamic";
+					case "Json": return IsGeneric ? "T" : (WithType ? "object" : "dynamic");
 					case "JsonList": return "IList<dynamic>";
 					//case "Xml": return ?;
 					case "String": return "string";
@@ -73,7 +77,7 @@ namespace Flurl.Http.CodeGen
 			get {
 				//var response = (xm.DeserializeToType == null) ? "" : "" + xm.TaskArg;
 				switch (ResponseBodyType) {
-					case "Json": return "the JSON response body deserialized to " + (IsGeneric ? "an object of type T" : "a dynamic");
+					case "Json": return "the JSON response body deserialized to " + (IsGeneric ? "an object of type T" : (WithType ? "object" : "a dynamic"));
 					case "JsonList": return "the JSON response body deserialized to a list of dynamics";
 					//case "Xml": return ?;
 					case "String": return "the response body as a string";

--- a/src/Flurl.Http.CodeGen/Program.cs
+++ b/src/Flurl.Http.CodeGen/Program.cs
@@ -90,6 +90,9 @@ namespace Flurl.Http.CodeGen
 					else
 			            writer.WriteLine("/// <param name=\"content\">Contents of the request body.</param>");
 	            }
+	            if (xm.WithType)
+		            writer.WriteLine("/// <param name=\"type\">The Type of object being deserialized.</param>");
+
 				writer.WriteLine("/// <param name=\"cancellationToken\">The token to monitor for cancellation requests.</param>");
 				writer.WriteLine("/// <param name=\"completionOption\">The HttpCompletionOption used in the request. Optional.</param>");
 				writer.WriteLine("/// <returns>A Task whose result is @0.</returns>", xm.ReturnTypeDescription);
@@ -102,6 +105,9 @@ namespace Flurl.Http.CodeGen
                     args.Add((xm.RequestBodyType == "String" ? "string" : "object") + " data");
 				else if (hasRequestBody)
 					args.Add("HttpContent content");
+
+				if(xm.WithType)
+					args.Add("Type type");
 
 				// http://stackoverflow.com/questions/22359706/default-parameter-for-cancellationtoken
 				args.Add("CancellationToken cancellationToken = default(CancellationToken)");
@@ -130,7 +136,12 @@ namespace Flurl.Http.CodeGen
 	                }
 
                     var request = (xm.ExtentionOfType == "IFlurlRequest") ? "request" : "new FlurlRequest(url)";
-                    var receive = (xm.ResponseBodyType == null) ? "" : string.Format(".Receive{0}{1}()", xm.ResponseBodyType, xm.IsGeneric ? "<T>" : "");
+
+					var receiveArgs = new List<string>();
+					if(xm.WithType)
+						receiveArgs.Add("type: type");
+					
+					var receive = (xm.ResponseBodyType == null) ? "" : string.Format(".Receive{0}{1}({2})", xm.ResponseBodyType, xm.IsGeneric ? "<T>" : "", string.Join(", ", receiveArgs));
                     writer.WriteLine("return @0.SendAsync(@1)@2;", request, string.Join(", ", args), receive);
                 }
                 else

--- a/src/Flurl.Http/Configuration/DefaultUrlEncodedSerializer.cs
+++ b/src/Flurl.Http/Configuration/DefaultUrlEncodedSerializer.cs
@@ -10,10 +10,7 @@ namespace Flurl.Http.Configuration
 	/// </summary>
 	public class DefaultUrlEncodedSerializer : ISerializer
 	{
-		/// <summary>
-		/// Serializes the specified object.
-		/// </summary>
-		/// <param name="obj">The object.</param>
+		/// <inheritdoc cref="ISerializer.Serialize"/>
 		public string Serialize(object obj) {
 			if (obj == null)
 				return null;
@@ -25,21 +22,13 @@ namespace Flurl.Http.Configuration
 			return qp.ToString(true);
 		}
 
-		/// <summary>
-		/// Deserializes the specified s.
-		/// </summary>
-		/// <typeparam name="T"></typeparam>
-		/// <param name="s">The s.</param>
+		/// <inheritdoc cref="ISerializer.Deserialize{T}(string)" />
 		/// <exception cref="NotImplementedException">Deserializing to UrlEncoded not supported.</exception>
 		public T Deserialize<T>(string s) {
 			throw new NotImplementedException("Deserializing to UrlEncoded is not supported.");
 		}
 
-		/// <summary>
-		/// Deserializes the specified stream.
-		/// </summary>
-		/// <typeparam name="T"></typeparam>
-		/// <param name="stream">The stream.</param>
+		/// <inheritdoc cref="ISerializer.Deserialize{T}(Stream)" />
 		/// <exception cref="NotImplementedException">Deserializing to UrlEncoded not supported.</exception>
 		public T Deserialize<T>(Stream stream) {
 			throw new NotImplementedException("Deserializing to UrlEncoded is not supported.");

--- a/src/Flurl.Http/Configuration/DefaultUrlEncodedSerializer.cs
+++ b/src/Flurl.Http/Configuration/DefaultUrlEncodedSerializer.cs
@@ -33,5 +33,17 @@ namespace Flurl.Http.Configuration
 		public T Deserialize<T>(Stream stream) {
 			throw new NotImplementedException("Deserializing to UrlEncoded is not supported.");
 		}
+
+		/// <inheritdoc cref="ISerializer.Deserialize(string, Type)" />
+		/// <exception cref="NotImplementedException">Deserializing to UrlEncoded not supported.</exception>
+		public object Deserialize(string s, Type type) {
+			throw new NotImplementedException("Deserializing to UrlEncoded is not supported.");
+		}
+
+		/// <inheritdoc cref="ISerializer.Deserialize(Stream, Type)" />
+		/// <exception cref="NotImplementedException">Deserializing to UrlEncoded not supported.</exception>
+		public object Deserialize(Stream stream, Type type) {
+			throw new NotImplementedException("Deserializing to UrlEncoded is not supported.");
+		}
 	}
 }

--- a/src/Flurl.Http/Configuration/ISerializer.cs
+++ b/src/Flurl.Http/Configuration/ISerializer.cs
@@ -13,14 +13,24 @@ namespace Flurl.Http.Configuration
 		/// <summary>
 		/// Serializes an object to a string representation.
 		/// </summary>
-	    string Serialize(object obj);
+		/// <param name="obj">The object to serialize.</param>
+		/// <returns>A JSON string representation of the object.</returns>
+		string Serialize(object obj);
+
 		/// <summary>
 		/// Deserializes an object from a string representation.
 		/// </summary>
+		/// <typeparam name="T">The type of the object to deserialize to.</typeparam>
+		/// <param name="s">The JSON to deserialize.</param>
+		/// <returns>The deserialized object from the JSON string.</returns>
 		T Deserialize<T>(string s);
+
 		/// <summary>
 		/// Deserializes an object from a stream representation.
 		/// </summary>
+		/// <typeparam name="T">The type of the object to deserialize to.</typeparam>
+		/// <param name="stream">The JSON stream to deserialize.</param>
+		/// <returns>The deserialized object from the JSON stram.</returns>
 		T Deserialize<T>(Stream stream);
-    }
+	}
 }

--- a/src/Flurl.Http/Configuration/ISerializer.cs
+++ b/src/Flurl.Http/Configuration/ISerializer.cs
@@ -32,5 +32,21 @@ namespace Flurl.Http.Configuration
 		/// <param name="stream">The JSON stream to deserialize.</param>
 		/// <returns>The deserialized object from the JSON stram.</returns>
 		T Deserialize<T>(Stream stream);
+
+		/// <summary>
+		/// Deserializes an object from a string representation.
+		/// </summary>
+		/// <param name="s">The JSON to deserialize.</param>
+		/// <param name="type">The Type of object being deserialized.</param>
+		/// <returns>The deserialized object from the JSON string.</returns>
+		object Deserialize(string s, Type type);
+
+		/// <summary>
+		/// Deserializes an object from a stream representation.
+		/// </summary>
+		/// <param name="stream">The JSON stream to deserialize.</param>
+		/// <param name="type">The Type of object being deserialized.</param>
+		/// <returns>The deserialized object from the JSON string.</returns>
+		object Deserialize(Stream stream, Type type);
 	}
 }

--- a/src/Flurl.Http/Configuration/NewtonsoftJsonSerializer.cs
+++ b/src/Flurl.Http/Configuration/NewtonsoftJsonSerializer.cs
@@ -27,18 +27,26 @@ namespace Flurl.Http.Configuration
 
 		/// <inheritdoc cref="ISerializer.Deserialize{T}(string)" />
 		public T Deserialize<T>(string s) {
-			return JsonConvert.DeserializeObject<T>(s, _settings);
+			return (T)Deserialize(s, typeof(T));
 		}
 
 		/// <inheritdoc cref="ISerializer.Deserialize{T}(Stream)" />
 		public T Deserialize<T>(Stream stream) {
+			return (T)Deserialize(stream, typeof(T));
+		}
+
+		/// <inheritdoc cref="ISerializer.Deserialize(string, Type)" />
+		public object Deserialize(string s, Type type) {
+			return JsonConvert.DeserializeObject(s, type, _settings);
+		}
+
+		/// <inheritdoc cref="ISerializer.Deserialize(Stream, Type)" />
+		public object Deserialize(Stream stream, Type type) {
 			// http://james.newtonking.com/json/help/index.html?topic=html/Performance.htm
 			using (var sr = new StreamReader(stream))
 			using (var jr = new JsonTextReader(sr)) {
-				return JsonSerializer.CreateDefault(_settings).Deserialize<T>(jr);
+				return JsonSerializer.CreateDefault(_settings).Deserialize(jr, type);
 			}
 		}
-
-
 	}
 }

--- a/src/Flurl.Http/Configuration/NewtonsoftJsonSerializer.cs
+++ b/src/Flurl.Http/Configuration/NewtonsoftJsonSerializer.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using Newtonsoft.Json;
 
 namespace Flurl.Http.Configuration
@@ -14,36 +15,22 @@ namespace Flurl.Http.Configuration
 		/// <summary>
 		/// Initializes a new instance of the <see cref="NewtonsoftJsonSerializer"/> class.
 		/// </summary>
-		/// <param name="settings">The settings.</param>
+		/// <param name="settings">The <see cref="JsonSerializerSettings"/> used to deserialize the object.</param>
 		public NewtonsoftJsonSerializer(JsonSerializerSettings settings) {
 			_settings = settings;
 		}
 
-		/// <summary>
-		/// Serializes the specified object.
-		/// </summary>
-		/// <param name="obj">The object.</param>
-		/// <returns></returns>
+		/// <inheritdoc cref="ISerializer.Serialize"/>
 		public string Serialize(object obj) {
 			return JsonConvert.SerializeObject(obj, _settings);
 		}
 
-		/// <summary>
-		/// Deserializes the specified s.
-		/// </summary>
-		/// <typeparam name="T"></typeparam>
-		/// <param name="s">The s.</param>
-		/// <returns></returns>
+		/// <inheritdoc cref="ISerializer.Deserialize{T}(string)" />
 		public T Deserialize<T>(string s) {
 			return JsonConvert.DeserializeObject<T>(s, _settings);
 		}
 
-		/// <summary>
-		/// Deserializes the specified stream.
-		/// </summary>
-		/// <typeparam name="T"></typeparam>
-		/// <param name="stream">The stream.</param>
-		/// <returns></returns>
+		/// <inheritdoc cref="ISerializer.Deserialize{T}(Stream)" />
 		public T Deserialize<T>(Stream stream) {
 			// http://james.newtonking.com/json/help/index.html?topic=html/Performance.htm
 			using (var sr = new StreamReader(stream))
@@ -51,5 +38,7 @@ namespace Flurl.Http.Configuration
 				return JsonSerializer.CreateDefault(_settings).Deserialize<T>(jr);
 			}
 		}
+
+
 	}
 }

--- a/src/Flurl.Http/FlurlHttpException.cs
+++ b/src/Flurl.Http/FlurlHttpException.cs
@@ -73,15 +73,25 @@ namespace Flurl.Http
 		/// <typeparam name="T">A type whose structure matches the expected JSON response.</typeparam>
 		/// <returns>A task whose result is an object containing data in the response body.</returns>
 		public async Task<T> GetResponseJsonAsync<T>() {
+			var result = await GetResponseJsonAsync(typeof(T));
+			return result == null ? default(T) : (T)result;
+		}
+
+		/// <summary>
+		/// Deserializes the JSON response body to an object of the given type.
+		/// </summary>
+		/// <param name="type">The Type of object being deserialized.</param>
+		/// <returns>A task whose result is an object containing data in the response body.</returns>
+		public async Task<object> GetResponseJsonAsync(Type type) {
 			var ser = Call.FlurlRequest?.Settings?.JsonSerializer;
-			if (ser == null) return default(T);
+			if (ser == null) return null;
 
 			if (_capturedResponseBody != null)
-				return ser.Deserialize<T>(_capturedResponseBody);
+				return ser.Deserialize(_capturedResponseBody, type);
 
 			var task = Call?.Response?.Content?.ReadAsStreamAsync();
-			if (task == null) return default(T);
-			return ser.Deserialize<T>(await task.ConfigureAwait(false));
+			if (task == null) return null;
+			return ser.Deserialize(await task.ConfigureAwait(false), type);
 		}
 
 		/// <summary>

--- a/src/Flurl.Http/GeneratedExtensions.cs
+++ b/src/Flurl.Http/GeneratedExtensions.cs
@@ -188,6 +188,18 @@ namespace Flurl.Http
 		/// Sends an asynchronous GET request.
 		/// </summary>
 		/// <param name="request">The IFlurlRequest instance.</param>
+		/// <param name="type">The Type of object being deserialized.</param>
+		/// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+		/// <param name="completionOption">The HttpCompletionOption used in the request. Optional.</param>
+		/// <returns>A Task whose result is the JSON response body deserialized to object.</returns>
+		public static Task<object> GetJsonAsync(this IFlurlRequest request, Type type, CancellationToken cancellationToken = default(CancellationToken), HttpCompletionOption completionOption = HttpCompletionOption.ResponseContentRead) {
+			return request.SendAsync(HttpMethod.Get, cancellationToken: cancellationToken, completionOption: completionOption).ReceiveJson(type: type);
+		}
+
+		/// <summary>
+		/// Sends an asynchronous GET request.
+		/// </summary>
+		/// <param name="request">The IFlurlRequest instance.</param>
 		/// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
 		/// <param name="completionOption">The HttpCompletionOption used in the request. Optional.</param>
 		/// <returns>A Task whose result is the JSON response body deserialized to a dynamic.</returns>
@@ -265,6 +277,18 @@ namespace Flurl.Http
 		/// Creates a FlurlRequest from the URL and sends an asynchronous GET request.
 		/// </summary>
 		/// <param name="url">The URL.</param>
+		/// <param name="type">The Type of object being deserialized.</param>
+		/// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+		/// <param name="completionOption">The HttpCompletionOption used in the request. Optional.</param>
+		/// <returns>A Task whose result is the JSON response body deserialized to object.</returns>
+		public static Task<object> GetJsonAsync(this Url url, Type type, CancellationToken cancellationToken = default(CancellationToken), HttpCompletionOption completionOption = HttpCompletionOption.ResponseContentRead) {
+			return new FlurlRequest(url).GetJsonAsync(type, cancellationToken, completionOption);
+		}
+
+		/// <summary>
+		/// Creates a FlurlRequest from the URL and sends an asynchronous GET request.
+		/// </summary>
+		/// <param name="url">The URL.</param>
 		/// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
 		/// <param name="completionOption">The HttpCompletionOption used in the request. Optional.</param>
 		/// <returns>A Task whose result is the JSON response body deserialized to a dynamic.</returns>
@@ -336,6 +360,18 @@ namespace Flurl.Http
 		/// <returns>A Task whose result is the JSON response body deserialized to an object of type T.</returns>
 		public static Task<T> GetJsonAsync<T>(this string url, CancellationToken cancellationToken = default(CancellationToken), HttpCompletionOption completionOption = HttpCompletionOption.ResponseContentRead) {
 			return new FlurlRequest(url).GetJsonAsync<T>(cancellationToken, completionOption);
+		}
+
+		/// <summary>
+		/// Creates a FlurlRequest from the URL and sends an asynchronous GET request.
+		/// </summary>
+		/// <param name="url">The URL.</param>
+		/// <param name="type">The Type of object being deserialized.</param>
+		/// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+		/// <param name="completionOption">The HttpCompletionOption used in the request. Optional.</param>
+		/// <returns>A Task whose result is the JSON response body deserialized to object.</returns>
+		public static Task<object> GetJsonAsync(this string url, Type type, CancellationToken cancellationToken = default(CancellationToken), HttpCompletionOption completionOption = HttpCompletionOption.ResponseContentRead) {
+			return new FlurlRequest(url).GetJsonAsync(type, cancellationToken, completionOption);
 		}
 
 		/// <summary>


### PR DESCRIPTION
Sometimes you only know the type of the JSON object at runtime. In this case, you cannot provide a generic type. Using the dynamic versions is also not an option because you maybe have attributes on the models.

This patchset added a few new methods to solve this. All existing generic versions of `Deserialize` and similar (like `Deserialize<T>(string)`, `Deserialize<T>(Stream)`, `ReceiveJson<T>`, ...) are refactored to internal call the Type version. So these changes will mostly be covered by existing tests but I also added some new tests for completeness.

It also contains a small patch with correcting and unifying the documentation of the ISerializer interface and his implementations.

- [x] The CodeGen project is updated to autogenerate methods with `Type` parameter
- [x] Tests are added
- [x] Issue created: #471

**ISerializer**
```
object ISerializer.Deserialize(string s, Type type)
object ISerializer.Deserialize(Stream stream, Type type)
object NewtonsoftJsonSerializer.Deserialize(string s, Type type)
object NewtonsoftJsonSerializer.Deserialize(Stream stream, Type type)
object DefaultUrlEncodedSerializer.Deserialize(string s, Type type)
object DefaultUrlEncodedSerializer.Deserialize(Stream stream, Type type)
```

**Methodes**
```
Task<object> HttpResponseMessage.ReceiveJson(this Task<HttpResponseMessage> response, Type type)
Task<object> IFlurlRequest.GetJsonAsync(this IFlurlRequest request, Type type, CancellationToken cancellationToken = default(CancellationToken), HttpCompletionOption completionOption = HttpCompletionOption.ResponseContentRead)
Task<object> Url.GetJsonAsync(this Url url, Type type, CancellationToken cancellationToken = default(CancellationToken), HttpCompletionOption completionOption = HttpCompletionOption.ResponseContentRead)
Task<object> string.GetJsonAsync(this string url, Type type, CancellationToken cancellationToken = default(CancellationToken), HttpCompletionOption completionOption = HttpCompletionOption.ResponseContentRead)
Task<object> FlurlHttpException.GetResponseJsonAsync(Type type)
```

**Tests**
```
GetTests.can_get_error_json_as_object
PostTests.can_receive_json_object

///new test fixture for deserialization tests: DeserializationTests
DeserializationTests.can_be_deserialize_int_generic
DeserializationTests.can_be_deserialize_int_type
DeserializationTests.can_be_deserialize_testdata_object_generic
DeserializationTests.can_be_deserialize_testdata_object_type
```