### PR TITLE
check if HttpClientHandler supports automatic decompression

### DIFF
--- a/src/Flurl.Http/Configuration/DefaultHttpClientFactory.cs
+++ b/src/Flurl.Http/Configuration/DefaultHttpClientFactory.cs
@@ -29,11 +29,13 @@ namespace Flurl.Http.Configuration
 		/// customize the result.
 		/// </summary>
 		public virtual HttpMessageHandler CreateMessageHandler() {
-			return new HttpClientHandler {
+			var httpClientHandler = new HttpClientHandler();
+			if (httpClientHandler.SupportsAutomaticDecompression) {
 				// #266
 				// deflate not working? see #474
-				AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate
-			};
+				httpClientHandler.AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate;
+			}
+			return httpClientHandler;
 		}
 	}
 }


### PR DESCRIPTION
Not all platforms where .NET runs on support automatic decrompression e.g. wasm.

See https://github.com/aspnet/AspNetCore/issues/17115 and https://github.com/aspnet/AspNetCore/issues/17115#issuecomment-556324814