### PR TITLE
Timeout assertions

### DIFF
--- a/Test/Flurl.Test/Http/TestingTests.cs
+++ b/Test/Flurl.Test/Http/TestingTests.cs
@@ -327,6 +327,29 @@ namespace Flurl.Test.Http
 		}
 
 		[Test]
+		public async Task can_assert_timeout() {
+			await "http://www.api.com/1".WithTimeout(TimeSpan.FromSeconds(2)).GetStringAsync();
+			await "http://www.api.com/2".WithTimeout(TimeSpan.FromSeconds(4)).GetStringAsync();
+			await "http://www.api.com/3".WithTimeout(TimeSpan.FromSeconds(8)).GetStringAsync();
+
+			HttpTest.ShouldHaveMadeACall().WithTimeoutGreaterThan(TimeSpan.FromSeconds(2)).Times(2);
+			HttpTest.ShouldHaveMadeACall().WithTimeoutGreaterThan(TimeSpan.FromSeconds(4)).Times(1);
+      
+			HttpTest.ShouldHaveMadeACall().WithTimeoutLessThan(TimeSpan.FromSeconds(8)).Times(2);
+			HttpTest.ShouldHaveMadeACall().WithTimeoutLessThan(TimeSpan.FromSeconds(4)).Times(1);
+      
+			HttpTest.ShouldHaveMadeACall().WithTimeout(TimeSpan.FromSeconds(2)).Times(1);
+			HttpTest.ShouldHaveMadeACall().WithTimeout(TimeSpan.FromSeconds(4)).Times(1);
+
+			Assert.Throws<HttpTestException>(() =>
+				HttpTest.ShouldHaveMadeACall().WithTimeoutGreaterThan(TimeSpan.FromSeconds(8)));
+			Assert.Throws<HttpTestException>(() =>
+				HttpTest.ShouldHaveMadeACall().WithTimeoutLessThan(TimeSpan.FromSeconds(2)));
+			Assert.Throws<HttpTestException>(() =>
+				HttpTest.ShouldHaveMadeACall().WithTimeout(TimeSpan.FromSeconds(3)));
+		}
+
+		[Test]
 		public async Task can_simulate_timeout() {
 			HttpTest.SimulateTimeout();
 			try {

--- a/src/Flurl.Http/Testing/HttpCallAssertion.cs
+++ b/src/Flurl.Http/Testing/HttpCallAssertion.cs
@@ -194,6 +194,36 @@ namespace Flurl.Http.Testing
 				"content type " + contentType);
 		}
 
+    /// <summary>
+    /// Asserts whether calls were made with a timeout greater than the given value.
+    /// </summary>
+    public HttpCallAssertion WithTimeoutGreaterThan(TimeSpan timeout)
+    {
+      return With(c =>
+        c.Request.Settings.Timeout > timeout,
+        "timeout greater than " + timeout);
+    }
+
+    /// <summary>
+    /// Asserts whether calls were made with a timeout equals to the given value.
+    /// </summary>
+    public HttpCallAssertion WithTimeout(TimeSpan timeout)
+    {
+      return With(c =>
+        c.Request.Settings.Timeout == timeout,
+        "timeout equals to " + timeout);
+    }
+
+    /// <summary>
+    /// Asserts whether calls were made with a timeout less than the given value.
+    /// </summary>
+    public HttpCallAssertion WithTimeoutLessThan(TimeSpan timeout)
+    {
+      return With(c =>
+         c.Request.Settings.Timeout < timeout,
+        "timeout less than " + timeout);
+    }
+
 		/// <summary>
 		/// Asserts whether an Authorization header was set with the given Bearer token, or any Bearer token if excluded.
 		/// Token can contain * wildcard.


### PR DESCRIPTION
I don’t know if it is intentional but since I have been using Flurl I always missed a top level API to assert timeouts. It is somewhat weird (maybe assymetrical?) that there is an API to set timeouts during request buiding but not to assert them during testing. I don’t know if it is not common out there to assert this kind of behaviour but usually at work we do in the following cenarious:

1. Integration with legacy APIs which suffer from bad performance (we assert that we are calling it with a timeout above a certain threshold, otherwise all calls will timeout);

2. Performance critical logic (if the call is not finished after some time, abort).

Based on these cenarious, it would be nice to have an API support to verify that a request was made with a timeout greater/less than a certain value.

By the way, I added a `WithTimeout` assertion just for completeness sake.