### PR TITLE
Tuple Support for Headers

### DIFF
--- a/Test/Flurl.Test/Http/SettingsExtensionsTests.cs
+++ b/Test/Flurl.Test/Http/SettingsExtensionsTests.cs
@@ -47,10 +47,10 @@ namespace Flurl.Test.Http
 
 		[Test]
 		public void can_set_headers_from_tuple() {
-			var sc = GetSettingsContainer().WithHeaders(("a", "b"), ("c", "d"));
+			var sc = GetSettingsContainer().WithHeaders(("a", 1), ("b", "c"));
 			Assert.AreEqual(2, sc.Headers.Count);
-			Assert.AreEqual("b", sc.Headers["a"]);
-			Assert.AreEqual("d", sc.Headers["c"]);
+			Assert.AreEqual(1, sc.Headers["a"]);
+			Assert.AreEqual("c", sc.Headers["b"]);
 		}
 
 		[Test]

--- a/Test/Flurl.Test/Http/SettingsExtensionsTests.cs
+++ b/Test/Flurl.Test/Http/SettingsExtensionsTests.cs
@@ -46,6 +46,14 @@ namespace Flurl.Test.Http
 		}
 
 		[Test]
+		public void can_set_headers_from_tuple() {
+			var sc = GetSettingsContainer().WithHeaders(("a", "b"), ("c", "d"));
+			Assert.AreEqual(2, sc.Headers.Count);
+			Assert.AreEqual("b", sc.Headers["a"]);
+			Assert.AreEqual("d", sc.Headers["c"]);
+		}
+
+		[Test]
 		public void can_remove_header_by_setting_null() {
 			var sc = GetSettingsContainer().WithHeaders(new { a = 1, b = 2 });
 			Assert.AreEqual(2, sc.Headers.Count);

--- a/src/Flurl.Http/Flurl.Http.csproj
+++ b/src/Flurl.Http/Flurl.Http.csproj
@@ -30,7 +30,8 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="Flurl" Version="3.0.0-pre3" />
-    <None Include="..\..\icon.png" Pack="true" PackagePath="\"/>
+    <PackageReference Include="System.ValueTuple" Version="4.3.0" />
+    <None Include="..\..\icon.png" Pack="true" PackagePath="\" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">

--- a/src/Flurl.Http/HeaderExtensions.cs
+++ b/src/Flurl.Http/HeaderExtensions.cs
@@ -11,66 +11,79 @@ namespace Flurl.Http
 	/// <summary>
 	/// Fluent extension methods for working with HTTP request headers.
 	/// </summary>
-    public static class HeaderExtensions
-    {
-	    /// <summary>
-	    /// Sets an HTTP header to be sent with this IFlurlRequest or all requests made with this IFlurlClient.
-	    /// </summary>
-	    /// <param name="clientOrRequest">The IFlurlClient or IFlurlRequest.</param>
-	    /// <param name="name">HTTP header name.</param>
-	    /// <param name="value">HTTP header value.</param>
-	    /// <returns>This IFlurlClient or IFlurlRequest.</returns>
-	    public static T WithHeader<T>(this T clientOrRequest, string name, object value) where T : IHttpSettingsContainer {
-		    if (value == null && clientOrRequest.Headers.ContainsKey(name))
-			    clientOrRequest.Headers.Remove(name);
+	public static class HeaderExtensions
+	{
+		/// <summary>
+		/// Sets an HTTP header to be sent with this IFlurlRequest or all requests made with this IFlurlClient.
+		/// </summary>
+		/// <param name="clientOrRequest">The IFlurlClient or IFlurlRequest.</param>
+		/// <param name="name">HTTP header name.</param>
+		/// <param name="value">HTTP header value.</param>
+		/// <returns>This IFlurlClient or IFlurlRequest.</returns>
+		public static T WithHeader<T>(this T clientOrRequest, string name, object value) where T : IHttpSettingsContainer {
+			if (value == null && clientOrRequest.Headers.ContainsKey(name))
+				clientOrRequest.Headers.Remove(name);
 			else if (value != null)
-			    clientOrRequest.Headers[name] = value;
-		    return clientOrRequest;
-	    }
+				clientOrRequest.Headers[name] = value;
+			return clientOrRequest;
+		}
 
-	    /// <summary>
-	    /// Sets HTTP headers based on property names/values of the provided object, or keys/values if object is a dictionary, to be sent with this IFlurlRequest or all requests made with this IFlurlClient.
-	    /// </summary>
-	    /// <param name="clientOrRequest">The IFlurlClient or IFlurlRequest.</param>
-	    /// <param name="headers">Names/values of HTTP headers to set. Typically an anonymous object or IDictionary.</param>
-	    /// <param name="replaceUnderscoreWithHyphen">If true, underscores in property names will be replaced by hyphens. Default is true.</param>
-	    /// <returns>This IFlurlClient or IFlurlRequest.</returns>
-	    public static T WithHeaders<T>(this T clientOrRequest, object headers, bool replaceUnderscoreWithHyphen = true) where T : IHttpSettingsContainer {
-		    if (headers == null)
-			    return clientOrRequest;
+		/// <summary>
+		/// Sets HTTP headers based on property names/values of the provided object, or keys/values if object is a dictionary, to be sent with this IFlurlRequest or all requests made with this IFlurlClient.
+		/// </summary>
+		/// <param name="clientOrRequest">The IFlurlClient or IFlurlRequest.</param>
+		/// <param name="headers">Names/values of HTTP headers to set. Typically an anonymous object or IDictionary.</param>
+		/// <param name="replaceUnderscoreWithHyphen">If true, underscores in property names will be replaced by hyphens. Default is true.</param>
+		/// <returns>This IFlurlClient or IFlurlRequest.</returns>
+		public static T WithHeaders<T>(this T clientOrRequest, object headers, bool replaceUnderscoreWithHyphen = true) where T : IHttpSettingsContainer {
+			if (headers == null)
+				return clientOrRequest;
 
 			// underscore replacement only applies when object properties are parsed to kv pairs
-		    replaceUnderscoreWithHyphen = replaceUnderscoreWithHyphen && !(headers is string) && !(headers is IEnumerable);
+			replaceUnderscoreWithHyphen = replaceUnderscoreWithHyphen && !(headers is string) && !(headers is IEnumerable);
 
-		    foreach (var kv in headers.ToKeyValuePairs()) {
-			    var key = replaceUnderscoreWithHyphen ? kv.Key.Replace("_", "-") : kv.Key;
-			    clientOrRequest.WithHeader(key, kv.Value);
-		    }
+			foreach (var kv in headers.ToKeyValuePairs()) {
+				var key = replaceUnderscoreWithHyphen ? kv.Key.Replace("_", "-") : kv.Key;
+				clientOrRequest.WithHeader(key, kv.Value);
+			}
 
-		    return clientOrRequest;
-	    }
+			return clientOrRequest;
+		}
 
-	    /// <summary>
-	    /// Sets HTTP authorization header according to Basic Authentication protocol to be sent with this IFlurlRequest or all requests made with this IFlurlClient.
-	    /// </summary>
-	    /// <param name="clientOrRequest">The IFlurlClient or IFlurlRequest.</param>
-	    /// <param name="username">Username of authenticating user.</param>
-	    /// <param name="password">Password of authenticating user.</param>
-	    /// <returns>This IFlurlClient or IFlurlRequest.</returns>
-	    public static T WithBasicAuth<T>(this T clientOrRequest, string username, string password) where T : IHttpSettingsContainer {
-		    // http://stackoverflow.com/questions/14627399/setting-authorization-header-of-httpclient
-		    var encodedCreds = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{username}:{password}"));
-		    return clientOrRequest.WithHeader("Authorization", $"Basic {encodedCreds}");
-	    }
+		/// <summary>
+		/// Sets HTTP headers based on name/value tuples, to be sent with this IFlurlRequest or all requests made with this IFlurlClient.
+		/// </summary>
+		/// <param name="clientOrRequest">The IFlurlClient or IFlurlRequest.</param>
+		/// <param name="headers">Names/values of HTTP headers to set.</param>
+		/// <returns>This IFlurlClient or IFlurlRequest.</returns>
+		public static T WithHeaders<T>(this T clientOrRequest, params (string Name, object Value)[] headers) where T : IHttpSettingsContainer {
+			foreach (var (name, value) in headers)
+				clientOrRequest.WithHeader(name, value);
 
-	    /// <summary>
-	    /// Sets HTTP authorization header with acquired bearer token according to OAuth 2.0 specification to be sent with this IFlurlRequest or all requests made with this IFlurlClient.
-	    /// </summary>
-	    /// <param name="clientOrRequest">The IFlurlClient or IFlurlRequest.</param>
-	    /// <param name="token">The acquired bearer token to pass.</param>
-	    /// <returns>This IFlurlClient or IFlurlRequest.</returns>
-	    public static T WithOAuthBearerToken<T>(this T clientOrRequest, string token) where T : IHttpSettingsContainer {
-		    return clientOrRequest.WithHeader("Authorization", $"Bearer {token}");
-	    }
-    }
+			return clientOrRequest;
+		}
+
+		/// <summary>
+		/// Sets HTTP authorization header according to Basic Authentication protocol to be sent with this IFlurlRequest or all requests made with this IFlurlClient.
+		/// </summary>
+		/// <param name="clientOrRequest">The IFlurlClient or IFlurlRequest.</param>
+		/// <param name="username">Username of authenticating user.</param>
+		/// <param name="password">Password of authenticating user.</param>
+		/// <returns>This IFlurlClient or IFlurlRequest.</returns>
+		public static T WithBasicAuth<T>(this T clientOrRequest, string username, string password) where T : IHttpSettingsContainer {
+			// http://stackoverflow.com/questions/14627399/setting-authorization-header-of-httpclient
+			var encodedCreds = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{username}:{password}"));
+			return clientOrRequest.WithHeader("Authorization", $"Basic {encodedCreds}");
+		}
+
+		/// <summary>
+		/// Sets HTTP authorization header with acquired bearer token according to OAuth 2.0 specification to be sent with this IFlurlRequest or all requests made with this IFlurlClient.
+		/// </summary>
+		/// <param name="clientOrRequest">The IFlurlClient or IFlurlRequest.</param>
+		/// <param name="token">The acquired bearer token to pass.</param>
+		/// <returns>This IFlurlClient or IFlurlRequest.</returns>
+		public static T WithOAuthBearerToken<T>(this T clientOrRequest, string token) where T : IHttpSettingsContainer {
+			return clientOrRequest.WithHeader("Authorization", $"Bearer {token}");
+		}
+	}
 }


### PR DESCRIPTION
Headers to allow the passing of tuples along these lines:

request.WithHeaders(("Accept", "application/json"), ("host", "localhost"), ("etc", "etc"))