### PR TITLE
Fix redirection when scheme is missing

### DIFF
--- a/Test/Flurl.Test/Http/RedirectTests.cs
+++ b/Test/Flurl.Test/Http/RedirectTests.cs
@@ -33,7 +33,7 @@ namespace Flurl.Test.Http
 				.With(call => call.RedirectedFrom.Request.Url.ToString() == "http://redir.com/foo");
 			HttpTest.ShouldHaveCalled("http://redir.com/redir2/redir3?x=1&y=2#foo").WithVerb(HttpMethod.Get).WithRequestBody("")
 				.With(call => call.RedirectedFrom.Request.Url.ToString() == "http://redir.com/redir2");
-			HttpTest.ShouldHaveCalled("http://otherredir.com/bar/?a=b").WithVerb(HttpMethod.Get).WithRequestBody("")
+			HttpTest.ShouldHaveCalled("http://otherredir.com/bar/?a=b#foo").WithVerb(HttpMethod.Get).WithRequestBody("")
 				.With(call => call.RedirectedFrom.Request.Url.ToString() == "http://redir.com/redir2/redir3?x=1&y=2#foo");
 		}
 

--- a/Test/Flurl.Test/Http/RedirectTests.cs
+++ b/Test/Flurl.Test/Http/RedirectTests.cs
@@ -18,12 +18,13 @@ namespace Flurl.Test.Http
 				.RespondWith("", 302, new { Location = "http://redir.com/foo" })
 				.RespondWith("", 302, new { Location = "/redir2" })
 				.RespondWith("", 302, new { Location = "redir3?x=1&y=2#foo" })
+				.RespondWith("", 302, new { Location = "//otherredir.com/bar/?a=b" })
 				.RespondWith("done!");
 
 			var resp = await "http://start.com".PostStringAsync("foo!").ReceiveString();
 
 			Assert.AreEqual("done!", resp);
-			HttpTest.ShouldHaveMadeACall().Times(4);
+			HttpTest.ShouldHaveMadeACall().Times(5);
 			HttpTest.ShouldHaveCalled("http://start.com").WithVerb(HttpMethod.Post).WithRequestBody("foo!")
 				.With(call => call.RedirectedFrom == null);
 			HttpTest.ShouldHaveCalled("http://redir.com/foo").WithVerb(HttpMethod.Get).WithRequestBody("")
@@ -32,6 +33,8 @@ namespace Flurl.Test.Http
 				.With(call => call.RedirectedFrom.Request.Url.ToString() == "http://redir.com/foo");
 			HttpTest.ShouldHaveCalled("http://redir.com/redir2/redir3?x=1&y=2#foo").WithVerb(HttpMethod.Get).WithRequestBody("")
 				.With(call => call.RedirectedFrom.Request.Url.ToString() == "http://redir.com/redir2");
+			HttpTest.ShouldHaveCalled("http://otherredir.com/bar/?a=b").WithVerb(HttpMethod.Get).WithRequestBody("")
+				.With(call => call.RedirectedFrom.Request.Url.ToString() == "http://redir.com/redir2/redir3?x=1&y=2#foo");
 		}
 
 		[Test]

--- a/src/Flurl.Http/FlurlRequest.cs
+++ b/src/Flurl.Http/FlurlRequest.cs
@@ -282,6 +282,8 @@ namespace Flurl.Http
 
 			if (Url.IsValid(location))
 				redir.Url = new Url(location);
+			else if (location.OrdinalStartsWith("//"))
+				redir.Url = new Url(this.Url.Scheme + ":" + location);
 			else if (location.OrdinalStartsWith("/"))
 				redir.Url = Url.Combine(this.Url.Root, location);
 			else


### PR DESCRIPTION
In some cases the http server responds with `//somedomain.com/hello?a=b`. With the old code this causes weird behavior where it would redirect to `https://domain.com/somedomain.com/hello?a=b`.

