### PR TITLE
Include TargetFramework net472 for Flurl and Flurl.Http

### DIFF
--- a/Test/Flurl.Test/Flurl.Test.csproj
+++ b/Test/Flurl.Test/Flurl.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net48</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net461;net472;net48</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -18,7 +18,7 @@
     <ProjectReference Include="..\..\src\Flurl.Http\Flurl.Http.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net48'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net472' Or '$(TargetFramework)' == 'net48'">
     <Reference Include="System.Net.Http" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>

--- a/src/Flurl.Http/Flurl.Http.csproj
+++ b/src/Flurl.Http/Flurl.Http.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net461;net472</TargetFrameworks>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <PackageId>Flurl.Http</PackageId>
     <Version>3.0.0</Version>
@@ -42,7 +42,7 @@
     <PackageReference Include="System.Text.Encoding.CodePages" Version="4.5.1" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net472'">
     <Reference Include="System.Net.Http" />
   </ItemGroup>
 

--- a/src/Flurl/Flurl.csproj
+++ b/src/Flurl/Flurl.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net461;net472;</TargetFrameworks>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <PackageId>Flurl</PackageId>
     <Version>3.0.0</Version>
@@ -14,7 +14,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageTags>fluent url uri querystring builder</PackageTags>
     <PackageReleaseNotes>https://github.com/tmenier/Flurl/releases</PackageReleaseNotes>
-	  <IncludeProjectPriFile>false</IncludeProjectPriFile>
+    <IncludeProjectPriFile>false</IncludeProjectPriFile>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
This pull request relates to #616.

I've added `net472` to the list of TargetFrameworks for the Flurl project.
I've also added `net472` to the list of TargetFrameworks for Flurl.Http as it references Flurl.

This will allow projects using `net472` or later to reference the Flurl NuGet package and not need to also reference the System.ValueTuple NuGet package.

The test project was previously targeting `netcoreapp3.1` and `net48`.
I've added `net461` and `net472` to the TargetFrameworks for the test project to ensure these targets work.

I wasn't sure if you still wanted `net48` left in the test project as a target now that I've also added net472? I've left it in for now but am happy to remove it.

I have also had a brief look at the PackageTester projects. Would you like me to also include projects for the new targets? I was a bit unsure of doing them as I'm not sure they're used, one of them is targeting `netcoreapp2.0` which no longer seems to be supported anyway.