### PR TITLE
Updates flurl to implement more thread safety

### DIFF
--- a/src/Flurl.Http/FlurlRequest.cs
+++ b/src/Flurl.Http/FlurlRequest.cs
@@ -106,7 +106,7 @@ namespace Flurl.Http
 
 		/// <inheritdoc />
 		public IFlurlClient Client {
-			get => 
+			get =>
 				(_client != null) ? _client :
 				(Url != null) ? FlurlHttp.GlobalSettings.FlurlClientFactory.Get(Url) :
 				null;
@@ -205,7 +205,7 @@ namespace Flurl.Http
 
 		private void SyncHeaders(HttpRequestMessage request) {
 			// copy any client-level (default) headers to this request
-			foreach (var header in Client.Headers.Where(h => !this.Headers.Contains(h.Name)))
+			foreach (var header in Client.Headers.Where(h => !this.Headers.Contains(h.Name)).ToList())
 				this.Headers.Add(header.Name, header.Value);
 
 			// copy headers from FlurlRequest to HttpRequestMessage

--- a/src/Flurl/QueryParamCollection.cs
+++ b/src/Flurl/QueryParamCollection.cs
@@ -1,4 +1,3 @@
-﻿using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -56,7 +55,7 @@ namespace Flurl
 				return;
 			}
 
-			foreach (var val in SplitCollection(value)) {
+			foreach (var val in SplitCollection(value).ToList()) {
 				if (val == null && nullValueHandling != NullValueHandling.NameOnly)
 					continue;
 				_values.Add(name, new QueryParamValue(val, isEncoded));
@@ -81,7 +80,6 @@ namespace Flurl
 			// example: x has values at positions 2 and 4 in the query string, then we set x to
 			// an array of 4 values. We want to replace the values at positions 2 and 4 with the
 			// first 2 values of the new array, then append the remaining 2 values to the end.
-			//var parameters = this.Where(p => p.Name == name).ToArray();
 			var values = new Queue<object>(SplitCollection(value));
 
 			var old = _values.ToArray();
@@ -93,7 +91,7 @@ namespace Flurl
 					continue;
 				}
 
-				if (!values.Any())
+				if (values.Count == 0)
 					continue; // remove, effectively
 
 				var val = values.Dequeue();
@@ -106,7 +104,7 @@ namespace Flurl
 			}
 
 			// add the rest to the end
-			while (values.Any()) {
+			while (values.Count > 0) {
 				Add(name, values.Dequeue(), isEncoded, nullValueHandling);
 			}
 		}
@@ -117,7 +115,7 @@ namespace Flurl
 			else if (value is string s)
 				yield return s;
 			else if (value is IEnumerable en) {
-				foreach (var item in en.Cast<object>().SelectMany(SplitCollection))
+				foreach (var item in en.Cast<object>().SelectMany(SplitCollection).ToList())
 					yield return item;
 			}
 			else


### PR DESCRIPTION
Our team ran into the same thread safety problems identified in #619. We were using it in the way similar to how @rcollette mentioned in that issue where we set an API key header at the client level because that was the easiest method for us. However, this setup frequently failed our unit tests with the error mentioned in the referenced issue. Following the advice listed there fixed our problems by changing our header setup from the client to the request level, but our team and others would appreciate if extra thread safety was added to syncing headers at the client level as well to simplify that headers setup.

My code changes were made based on advice from this stack overflow question: https://stackoverflow.com/questions/604831/collection-was-modified-enumeration-operation-may-not-execute

To me, it seems worth it to make these changes because it is a minor impact to performance to better guarantee thread safety.

- Manual testing when setting up the headers at the client level:
    - Before these changes, our team's unit tests passed 57 times out of 100 tests.
    - After these changes, our team's unit tests passed 100 times out 100 tests.

**Note:** I was only able to test the changes made to the `FlurlRequest.cs` file since that is what affected our code. The changes made to `QueryParamCollection.cs` are all theoretical based on a comment from @malylemire1 and can be removed or modified if you want since I was not able to test it with my code.
