### PR TITLE
#656 QueryParams contains bug

### DIFF
--- a/Test/Flurl.Test/UrlBuilder/UrlParsingTests.cs
+++ b/Test/Flurl.Test/UrlBuilder/UrlParsingTests.cs
@@ -115,5 +115,13 @@ namespace Flurl.Test.UrlBuilder
 			var url = new Url(expected);
 			Assert.AreEqual(expected, url.ToString());
 		}
+
+		[Test] // #656
+		public void queryparams_uses_equals() {
+			var url = new Url("http://www.mysite.com?param=1");
+			// String gets boxed, so we need to use Equals, instead of ==
+			var contains = url.QueryParams.Contains("param", "1");
+			Assert.IsTrue(contains);
+		}
 	}
 }

--- a/src/Flurl/QueryParamCollection.cs
+++ b/src/Flurl/QueryParamCollection.cs
@@ -161,7 +161,7 @@ namespace Flurl
 		public bool Contains(string name) => _values.Contains(name);
 
 		/// <inheritdoc />>
-		public bool Contains(string name, object value) => _values.Any(qv => qv.Name == name && qv.Value.Value == value);
+		public bool Contains(string name, object value) => _values.Any(qv => qv.Name == name && qv.Value.Value.Equals(value));
 	}
 
 	/// <summary>


### PR DESCRIPTION
Fixes an issue where QueryParams contains would fail, because boxed strings don't == each other.

The bug is caused because of how equality works with strings
```c#
object a2 = "hello";
object b2 = "_hello".Substring(1,5);
// a2 == b2 is false
// a2.Equals(b2) is true
```

Fixes #656