### PR TITLE
#673 HttpTest Response based on request

### DIFF
--- a/Test/Flurl.Test/Http/TestingTests.cs
+++ b/Test/Flurl.Test/Http/TestingTests.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Flurl.Http;
+using Flurl.Http.Content;
 using Flurl.Http.Testing;
 using NUnit.Framework;
 
@@ -498,6 +499,22 @@ namespace Flurl.Test.Http
 					test.ShouldHaveMadeACall().Times(10);
 				}
 			}
+		}
+
+		[Test] // #673
+		public async Task can_use_request_in_response()
+		{
+			HttpTest.RespondWith(request =>
+			{
+				var requestBody = request.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+				return new CapturedStringContent(requestBody);
+			});
+
+			var receivedString = await "http://api.com"
+				.PostStringAsync("hello world")
+				.ReceiveString();
+			
+			Assert.AreEqual("hello world", receivedString);
 		}
 	}
 }

--- a/src/Flurl.Http/Testing/FakeHttpMessageHandler.cs
+++ b/src/Flurl.Http/Testing/FakeHttpMessageHandler.cs
@@ -30,7 +30,7 @@ namespace Flurl.Http.Testing
 					HttpTest.Current.LogCall(call);
 					var setup = HttpTest.Current.FindSetup(call);
 					if (setup?.FakeRequest == true) {
-						var resp = setup.GetNextResponse() ?? new HttpResponseMessage {
+						var resp = setup.GetNextResponse(request) ?? new HttpResponseMessage {
 							StatusCode = HttpStatusCode.OK,
 							Content = new StringContent("")
 						};


### PR DESCRIPTION
Allow HttpTest.RespondWith to access the request when constructing the response.