### PR TITLE
Added a Method to Http Test to simulate exceptions thrown when requests are made

### DIFF
--- a/Test/Flurl.Test/Http/TestingTests.cs
+++ b/Test/Flurl.Test/Http/TestingTests.cs
@@ -363,7 +363,7 @@ namespace Flurl.Test.Http
 		}
 
 		[Test]
-		public async Task can_simulate_excepion() {
+		public async Task can_simulate_exception() {
 			var expectedException = new SocketException();
 			HttpTest.SimulateException(expectedException);
 			try {

--- a/Test/Flurl.Test/Http/TestingTests.cs
+++ b/Test/Flurl.Test/Http/TestingTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Net.Http;
+using System.Net.Sockets;
 using System.Threading.Tasks;
 using Flurl.Http;
 using Flurl.Http.Testing;
@@ -361,7 +362,20 @@ namespace Flurl.Test.Http
 			}
 		}
 
-	    [Test]
+		[Test]
+		public async Task can_simulate_excepion() {
+			var expectedException = new SocketException();
+			HttpTest.SimulateException(expectedException);
+			try {
+				await "http://www.api.com".GetAsync();
+				Assert.Fail("Exception was not thrown!");
+			}
+			catch (FlurlHttpException ex) {
+				Assert.AreEqual(expectedException, ex.InnerException);
+			}
+		}
+
+		[Test]
 	    public async Task can_simulate_timeout_with_exception_handled() {
 	        HttpTest.SimulateTimeout();
 	        var result = await "http://www.api.com"

--- a/src/Flurl.Http/Testing/HttpTest.cs
+++ b/src/Flurl.Http/Testing/HttpTest.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Net.Http;
+using System.Net.Sockets;
 using Flurl.Http.Configuration;
 
 namespace Flurl.Http.Testing

--- a/src/Flurl.Http/Testing/HttpTest.cs
+++ b/src/Flurl.Http/Testing/HttpTest.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Net.Http;
-using System.Net.Sockets;
 using Flurl.Http.Configuration;
 
 namespace Flurl.Http.Testing

--- a/src/Flurl.Http/Testing/HttpTestSetup.cs
+++ b/src/Flurl.Http/Testing/HttpTestSetup.cs
@@ -111,6 +111,16 @@ namespace Flurl.Http.Testing
 		}
 
 		/// <summary>
+		/// Add the throwing of an exception to the response queue
+		/// </summary>
+		/// <param name="exception"></param>
+		/// <returns></returns>
+		public HttpTestSetup SimulateException(Exception exception) {
+			_responses.Add(() => throw exception);
+			return this;
+		}
+
+		/// <summary>
 		/// Do NOT fake requests for this setup. Typically called on a filtered setup, i.e. HttpTest.ForCallsTo(urlPattern).AllowRealHttp();
 		/// </summary>
 		public void AllowRealHttp() {


### PR DESCRIPTION
Added an http test method allowing any exception to be raised when a request is made. For the purpose of allowing tests of socket exception and other http exception that can be raised when making an http call.
#554 