### PR TITLE
Upgrade Newtonsoft.Json to 13.0.1

### DIFF
--- a/src/Flurl.Http/Flurl.Http.csproj
+++ b/src/Flurl.Http/Flurl.Http.csproj
@@ -37,10 +37,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Flurl" Version="3.0.6" />
-    <None Include="..\..\icon.png" Pack="true" PackagePath="\"/>
+    <None Include="..\..\icon.png" Pack="true" PackagePath="\" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">


### PR DESCRIPTION
Current version of Newtonsoft.Json has insecure defaults that can lead to stackoverflow exception. This has been fixed in v13.0.1

https://security.snyk.io/vuln/SNYK-DOTNET-NEWTONSOFTJSON-2774678
