### PR TITLE
Url validation fix

### DIFF
--- a/Test/Flurl.Test/Http/RealHttpTests.cs
+++ b/Test/Flurl.Test/Http/RealHttpTests.cs
@@ -40,6 +40,7 @@ namespace Flurl.Test.Http
 		[TestCase("https://httpbin.org/response-headers", "attachment", null, "response-headers")]
 		public async Task can_download_file(string url, string contentDisposition, string suppliedFilename, string expectedFilename) {
 			var folder = Path.Combine(Path.GetTempPath(), $"flurl-test-{Guid.NewGuid()}"); // random so parallel tests don't trip over each other
+			Directory.CreateDirectory(folder);
 
 			try {
 				var path = await url.SetQueryParam("Content-Disposition", contentDisposition).DownloadFileAsync(folder, suppliedFilename);

--- a/Test/Flurl.Test/UrlBuilder/UtilityMethodTests.cs
+++ b/Test/Flurl.Test/UrlBuilder/UtilityMethodTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -74,6 +74,10 @@ namespace Flurl.Test.UrlBuilder
 		[TestCase("blah", false)]
 		[TestCase("http:/www.mysite.com", false)]
 		[TestCase("www.mysite.com", false)]
+		[TestCase("https://example.com/%C3%A5%2A", true)]
+		[TestCase("https://example.com/%E0%B8%95%E0%B8%B1%2A", true)]
+		[TestCase("https://example.com:999/api/path.cgi?u=uname&p=P%C3%B3%5E78", true)]
+		[TestCase("https://example.com:999/api/path.cgi?u=uname&p=P%C378", true)]
 		public void IsValid_works(string s, bool isValid) {
 			Assert.AreEqual(isValid, Url.IsValid(s));
 		}

--- a/src/Flurl/Url.cs
+++ b/src/Flurl/Url.cs
@@ -679,7 +679,19 @@ namespace Flurl
 		/// </summary>
 		/// <param name="url">The string to check</param>
 		/// <returns>true if the string is a well-formed absolute URL</returns>
-		public static bool IsValid(string url) => url != null && Uri.IsWellFormedUriString(url, UriKind.Absolute);
+		public static bool IsValid(string url) {
+			if (url is null)
+				return false;
+
+			if (!Uri.TryCreate(url, UriKind.Absolute, out var result))
+				return false;
+
+			//Non-Ascii characters combined with URI reserved characters make IsWellFormedUriString return false
+			//even though url is correct https://stackoverflow.com/a/62411610/2380881
+			//IsWellFormedUriString is only needed to check if there is no path and query in url
+			return !string.IsNullOrEmpty(result?.PathAndQuery) || Uri.IsWellFormedUriString(url, UriKind.Absolute);
+		}
+
 		#endregion
 	}
 }


### PR DESCRIPTION
Because Uri.IsWellFormedUriString method implementation differs on .NET Framework and .NET Url.IsValid will return contrary results on different frameworks. To fix that, I changed IsValid implementation to check only URL base and try to create Uri from the whole string, as you see in the proposed change. I've also added test cases for failing URLs.