### PR TITLE
Exception caused by automatic redirection resulting in the destructio…

### DIFF
--- a/src/Flurl.Http/Flurl.Http.csproj
+++ b/src/Flurl.Http/Flurl.Http.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>netstandard2.0;net461;net472</TargetFrameworks>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <PackageId>Flurl.Http</PackageId>
-    <Version>3.2.4</Version>
+    <Version>3.2.5</Version>
     <Authors>Todd Menier</Authors>
     <Description>A fluent, portable, testable HTTP client library.</Description>
     <PackageProjectUrl>https://flurl.dev</PackageProjectUrl>

--- a/src/Flurl.Http/HttpContentExtensions.cs
+++ b/src/Flurl.Http/HttpContentExtensions.cs
@@ -1,0 +1,38 @@
+﻿using System.IO;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Flurl.Http
+{
+	/// <summary>
+	/// Extension methods of HttpContent
+	/// </summary>
+	public static class HttpContentExtensions
+	{
+		/// <summary>Get a copy of the request content.</summary>
+		/// <param name="content">The content to copy.</param>
+		/// <param name="cancellationToken">The cancellation token.</param>
+		/// <remarks>Note that cloning content isn't possible after it's dispatched, because the stream is automatically disposed after the request.</remarks>
+		internal static async Task<HttpContent> CloneAsync(this HttpContent content, CancellationToken cancellationToken = default) {
+			if (content == null)
+				return null;
+
+			Stream stream = new MemoryStream();
+			await content
+				.CopyToAsync(stream
+#if NET5_0_OR_GREATER
+					, cancellationToken
+#endif
+				)
+				.ConfigureAwait(false);
+			stream.Position = 0;
+
+			StreamContent clone = new StreamContent(stream);
+			foreach (var header in content.Headers)
+				clone.Headers.Add(header.Key, header.Value);
+
+			return clone;
+		}
+	}
+}


### PR DESCRIPTION
Exception caused by automatic redirection resulting in the destruction of HttpContent in .NET Framework 4.6.x and 4.7.x is fixed.

see:
https://github.com/tmenier/Flurl/issues/644
https://github.com/dotnet/runtime/issues/14612
https://github.com/dotnet/corefx/pull/19082