### PR TITLE
Handle empty lists in SetQueryParams

### DIFF
--- a/src/Flurl/QueryParamCollection.cs
+++ b/src/Flurl/QueryParamCollection.cs
@@ -55,7 +55,14 @@ namespace Flurl
 				return;
 			}
 
-			foreach (var val in SplitCollection(value).ToList()) {
+			if (value is IEnumerable en && !en.Cast<object>().Any() && !(en is string)) {
+				if(!_values.Contains($"{name}[0]"))
+					_values.Add($"{name}[0]", new QueryParamValue("", isEncoded));
+				return;
+			}
+
+			foreach (var val in SplitCollection(value).ToList())
+			{
 				if (val == null && nullValueHandling != NullValueHandling.NameOnly)
 					continue;
 				_values.Add(name, new QueryParamValue(val, isEncoded));
@@ -114,7 +121,7 @@ namespace Flurl
 				yield return null;
 			else if (value is string s)
 				yield return s;
-			else if (value is IEnumerable en) {
+			else if (value is IEnumerable en && (en.Cast<object>().Any() || en is string)) {
 				foreach (var item in en.Cast<object>().SelectMany(SplitCollection).ToList())
 					yield return item;
 			}

--- a/test/Flurl.Test/UrlBuilder/UrlBuildingTests.cs
+++ b/test/Flurl.Test/UrlBuilder/UrlBuildingTests.cs
@@ -126,11 +126,32 @@ namespace Flurl.Test.UrlBuilder
 			Assert.AreEqual("https://api.com?Values=1&Values=2&Values=3", url.ToString());
 		}
 
+		[Test]
+		public void handle_set_query_params_with_empty_list() {
+			var model = new ModelWithIEnumerable { Values = new List<int>() };
+			var url = "https://api.com".SetQueryParams(model);
+			Assert.AreEqual("https://api.com?Values[0]=", url.ToString());
+		}
+
+		[Test]
+		public void handle_replace_set_query_params_with_empty_list() {
+			var model = new ModelWithIEnumerable { Values = new List<int>() };
+			var url = "https://api.com?Values=test".SetQueryParams(model);
+			Assert.AreEqual("https://api.com?Values[0]=", url.ToString());
+		}
+
 		[Test] // #672
 		public void can_append_query_params_using_object_with_ienumerable() {
 			var model = new ModelWithIEnumerable { Values = Enumerable.Range(1, 3).ToArray() };
 			var url = "https://api.com".AppendQueryParam(model);
 			Assert.AreEqual("https://api.com?Values=1&Values=2&Values=3", url.ToString());
+		}
+
+		[Test]
+		public void handle_append_query_param_with_empty_list() {
+			var model = new ModelWithIEnumerable { Values = new List<int>() };
+			var url = "https://api.com".AppendQueryParam(model);
+			Assert.AreEqual("https://api.com?Values[0]=", url.ToString());
 		}
 
 		class ModelWithIEnumerable


### PR DESCRIPTION
I made some changes in order to handles empty lists in Query Params.

I had an issue before in my code because it was handling null and empty lists the same way. Therefore, my code set an empty list query parameter for instantiated but empty list and no query param for list which are null.