### PR TITLE
Fix https://github.com/tmenier/Flurl/issues/794

### DIFF
--- a/src/Flurl.Http/Configuration/DefaultJsonSerializer.cs
+++ b/src/Flurl.Http/Configuration/DefaultJsonSerializer.cs
@@ -35,6 +35,8 @@ namespace Flurl.Http.Configuration
 		/// Deserializes the specified stream to an object of type T.
 		/// </summary>
 		/// <param name="stream">The stream to deserialize.</param>
-		public T Deserialize<T>(Stream stream) => stream.Length == 0 ? default : JsonSerializer.Deserialize<T>(stream, _options);
+		public T Deserialize<T>(Stream stream) => stream.CanSeek && stream.Length == 0
+			? default
+			: JsonSerializer.Deserialize<T>(stream, _options);
 	}
 }

--- a/test/Flurl.Test/Http/RealHttpTests.cs
+++ b/test/Flurl.Test/Http/RealHttpTests.cs
@@ -61,6 +61,19 @@ namespace Flurl.Test.Http
 		}
 
 		[Test]
+		[TestCase(HttpCompletionOption.ResponseHeadersRead)]
+		[TestCase(HttpCompletionOption.ResponseContentRead)]
+		public async Task can_get_json_with_http_completion_option_headers(HttpCompletionOption completionOption)
+		{
+			var result = await "https://httpbin.org"
+				.AppendPathSegment("gzip")
+				.WithHeader("Accept-encoding", "gzip")
+				.GetJsonAsync<Dictionary<string, object>>(completionOption);
+
+			Assert.AreEqual(true, ((JsonElement)result["gzipped"]).GetBoolean());
+		}
+
+		[Test]
 		public async Task can_get_stream() {
 			using (var stream = await "https://www.google.com".GetStreamAsync())
 			using (var ms = new MemoryStream()) {


### PR DESCRIPTION
PR containing failing test demonstrating issue #794
@tmenier 

Issue is due to stream.Length accessing Length property throws on GzipStream in DefaultJsonSerializer.