### PR TITLE
Fix incorrect XML doc about default JSON serializer

### DIFF
--- a/src/Flurl.Http/Configuration/FlurlHttpSettings.cs
+++ b/src/Flurl.Http/Configuration/FlurlHttpSettings.cs
@@ -68,7 +68,7 @@ namespace Flurl.Http.Configuration
 		}
 
 		/// <summary>
-		/// Gets or sets object used to serialize and deserialize JSON. Default implementation uses Newtonsoft Json.NET.
+		/// Gets or sets object used to serialize and deserialize JSON. Default implementation uses System.Text.Json.
 		/// </summary>
 		public ISerializer JsonSerializer {
 			get => Get<ISerializer>();


### PR DESCRIPTION
Hi,

Just posting a tiny piece that bugged me. Default JSON serializer implemention is based on `System.Text.Json`, so I fixed the XML doc to reflect that.

Cheers