### PR TITLE
Autorenew OAuth Tokens

### DIFF
--- a/src/Flurl.CodeGen/Metadata.cs
+++ b/src/Flurl.CodeGen/Metadata.cs
@@ -146,7 +146,7 @@ namespace Flurl.CodeGen
 				.AddArg("enabled", "bool", "true if Flurl should automatically send a new request to the redirect URL, false if it should not.");
 			yield return Create("WithOAuthTokenProvider", "Creates a new FlurlRequest and configures it to use the supplied OAuth token provider for the request's authentication header")
 				.AddArg("tokenProvider","IOAuthTokenProvider", "the token provider");
-			yield return Create("WithOAuthScope", "Creates a new FlurlRequest and configures it to request an OAuth bearer token of the specified scope from the OAuth token provider")
+			yield return Create("WithOAuthTokenFromProvider", "Creates a new FlurlRequest and configures it to request an OAuth bearer token of the specified scope from the OAuth token provider")
 				.AddArg("scope","string","The scope of the token");
 
 			// event handler extensions

--- a/src/Flurl.CodeGen/Metadata.cs
+++ b/src/Flurl.CodeGen/Metadata.cs
@@ -8,7 +8,7 @@ namespace Flurl.CodeGen
 	public static class Metadata
 	{
 		/// <summary>
-		/// Mirrors methods defined on Url. We'll auto-gen them for Uri and string. 
+		/// Mirrors methods defined on Url. We'll auto-gen them for Uri and string.
 		/// </summary>
 		public static IEnumerable<ExtensionMethod> GetUrlReturningExtensions(MethodArg extendedArg) {
 			ExtensionMethod Create(string name, string descrip) => new ExtensionMethod(name, descrip)
@@ -97,7 +97,7 @@ namespace Flurl.CodeGen
 		}
 
 		/// <summary>
-		/// Mirrors methods defined on IFlurlRequest and IFlurlClient. We'll auto-gen them for Url, Uri, and string. 
+		/// Mirrors methods defined on IFlurlRequest and IFlurlClient. We'll auto-gen them for Url, Uri, and string.
 		/// </summary>
 		public static IEnumerable<ExtensionMethod> GetRequestReturningExtensions(MethodArg extendedArg) {
 			ExtensionMethod Create(string name, string descrip) => new ExtensionMethod(name, descrip)
@@ -146,6 +146,8 @@ namespace Flurl.CodeGen
 				.AddArg("enabled", "bool", "true if Flurl should automatically send a new request to the redirect URL, false if it should not.");
 			yield return Create("WithOAuthTokenProvider", "Creates a new FlurlRequest and configures it to use the supplied OAuth token provider for the request's authentication header")
 				.AddArg("tokenProvider","IOAuthTokenProvider", "the token provider");
+			yield return Create("WithOAuthScope", "Creates a new FlurlRequest and configures it to request an OAuth bearer token of the specified scope from the OAuth token provider")
+				.AddArg("scope","string","The scope of the token");
 
 			// event handler extensions
 			foreach (var name in new[] { "BeforeCall", "AfterCall", "OnError", "OnRedirect" }) {

--- a/src/Flurl.CodeGen/Metadata.cs
+++ b/src/Flurl.CodeGen/Metadata.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -144,6 +144,8 @@ namespace Flurl.CodeGen
 			yield return Create("AllowAnyHttpStatus", "Creates a new FlurlRequest and configures it to allow any returned HTTP status without throwing a FlurlHttpException.");
 			yield return Create("WithAutoRedirect", "Creates a new FlurlRequest and configures whether redirects are automatically followed.")
 				.AddArg("enabled", "bool", "true if Flurl should automatically send a new request to the redirect URL, false if it should not.");
+			yield return Create("WithOAuthTokenProvider", "Creates a new FlurlRequest and configures it to use the supplied OAuth token provider for the request's authentication header")
+				.AddArg("tokenProvider","IOAuthTokenProvider", "the token provider");
 
 			// event handler extensions
 			foreach (var name in new[] { "BeforeCall", "AfterCall", "OnError", "OnRedirect" }) {

--- a/src/Flurl.CodeGen/Metadata.cs
+++ b/src/Flurl.CodeGen/Metadata.cs
@@ -146,8 +146,8 @@ namespace Flurl.CodeGen
 				.AddArg("enabled", "bool", "true if Flurl should automatically send a new request to the redirect URL, false if it should not.");
 			yield return Create("WithOAuthTokenProvider", "Creates a new FlurlRequest and configures it to use the supplied OAuth token provider for the request's authentication header")
 				.AddArg("tokenProvider","IOAuthTokenProvider", "the token provider");
-			yield return Create("WithOAuthTokenFromProvider", "Creates a new FlurlRequest and configures it to request an OAuth bearer token of the specified scope from the OAuth token provider")
-				.AddArg("scope","string","The scope of the token");
+			yield return Create("WithOAuthTokenFromProvider", "Creates a new FlurlRequest and configures it to request an OAuth bearer token of the specified scope(s) from the OAuth token provider")
+				.AddArg("scopes","params string[]","The scope(s) of the token");
 
 			// event handler extensions
 			foreach (var name in new[] { "BeforeCall", "AfterCall", "OnError", "OnRedirect" }) {

--- a/src/Flurl.CodeGen/Program.cs
+++ b/src/Flurl.CodeGen/Program.cs
@@ -55,6 +55,7 @@ namespace Flurl.CodeGen
 						.WriteLine("using System.Net.Http;")
 						.WriteLine("using System.Threading;")
 						.WriteLine("using System.Threading.Tasks;")
+						.WriteLine("using Flurl.Http.Authentication;")
 						.WriteLine("using Flurl.Http.Configuration;")
 						.WriteLine("using Flurl.Http.Content;")
 						.WriteLine("")

--- a/src/Flurl.Http/Authentication/ClientCredentialsOAuthTokenProvider.cs
+++ b/src/Flurl.Http/Authentication/ClientCredentialsOAuthTokenProvider.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+
+namespace Flurl.Http.Authentication
+{
+    /// <summary>
+    ///
+    /// </summary>
+    public class ClientCredentialsTokenProvider : OAuthTokenProvider
+    {
+        private readonly string _clientId;
+        private readonly string _clientSecret;
+        private readonly IFlurlClient _fc;
+
+        /// <summary>
+        /// Instantiates a new OAuthTokenProvider that uses clientId/clientSecret as an authentication mechanism
+        /// </summary>
+        /// <param name="clientId">The client id to send when making requests for the OAuth token</param>
+        /// <param name="client">The <see cref="IFlurlClient"/> to use when making requests for the OAuth token. Leave null to omit this property from the body of the request</param>
+        /// <param name="clientSecret">The client secret to send when making requests for the OAuth token</param>
+        /// <param name="earlyExpiration">The amount of time that defines how much earlier a entry should be considered expired relative to its actual expiration</param>
+        /// <param name="authenticationScheme">The authentication scheme this provider will provide in the resolved authentication header. Usually "Bearer" or "OAuth"</param>
+        public ClientCredentialsTokenProvider(string clientId,
+                                            string clientSecret,
+                                            IFlurlClient client,
+                                            TimeSpan? earlyExpiration = null,
+                                            string authenticationScheme = "Bearer")
+            : base(earlyExpiration, authenticationScheme)
+        {
+            _clientId = clientId;
+            _clientSecret = clientSecret;
+            _fc = client;
+        }
+
+        /// <summary>
+        /// Gets the OAuth authentication header for the specified scope
+        /// </summary>
+        /// <param name="scope">The desired scope</param>
+        /// <returns></returns>
+        protected override async Task<ExpirableToken> GetToken(string scope)
+        {
+            var now = DateTimeOffset.Now;
+
+            var body = new Dictionary<string, string>
+            {
+                ["client_id"] = _clientId,
+                ["scope"] = scope,
+                ["grant_type"] = "client_credentials"
+            };
+
+            if (string.IsNullOrWhiteSpace(_clientSecret) == false)
+            { body["client_secret"] = _clientSecret; }
+
+            var rawResponse = await _fc.Request("connect", "token")
+                                        .AllowAnyHttpStatus()
+                                        .PostUrlEncodedAsync(body);
+
+            if (rawResponse.StatusCode >= 200 && rawResponse.StatusCode < 300)
+            {
+                var tokenResponse = await rawResponse.GetJsonAsync<JsonNode>();
+                var expiration = now.AddSeconds(tokenResponse["expires_in"].GetValue<int>());
+
+                return new ExpirableToken(tokenResponse["access_token"].GetValue<string>(), expiration);
+            }
+            if (rawResponse.StatusCode == 400)
+            {
+                var errorMessage = default(string);
+                try
+                {
+                    var response = await rawResponse.GetJsonAsync<JsonNode>();
+                    errorMessage = response["error"].GetValue<string>();
+
+                    if (errorMessage == "invalid_scope")
+                    { errorMessage = $"{_clientId} is not allowed to utilize scope {scope}, or {scope} is not a valid scope. Verify the allowed scopes for {_clientId} and try again."; }
+                }
+                catch (Exception)
+                {
+                    errorMessage = $"{_clientId} is not allowed to utilize scope {scope}, or {scope} is not a valid scope. Verify the allowed scopes for {_clientId} and try again.";
+                }
+
+                throw new UnauthorizedAccessException(errorMessage);
+            }
+            else
+            {
+                throw new UnauthorizedAccessException("Unable to acquire OAuth token");
+            }
+        }
+    }
+}
+
+

--- a/src/Flurl.Http/Authentication/ClientCredentialsOAuthTokenProvider.cs
+++ b/src/Flurl.Http/Authentication/ClientCredentialsOAuthTokenProvider.cs
@@ -55,6 +55,7 @@ namespace Flurl.Http.Authentication
             { body["client_secret"] = _clientSecret; }
 
             var rawResponse = await _fc.Request("connect", "token")
+                                        .WithHeader("accept","application/json")
                                         .AllowAnyHttpStatus()
                                         .PostUrlEncodedAsync(body);
 

--- a/src/Flurl.Http/Authentication/ClientCredentialsTokenProvider.cs
+++ b/src/Flurl.Http/Authentication/ClientCredentialsTokenProvider.cs
@@ -1,13 +1,12 @@
 using System;
 using System.Collections.Generic;
-using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Threading.Tasks;
 
 namespace Flurl.Http.Authentication
 {
     /// <summary>
-    ///
+    /// OAuth token provider that uses client credentials as an authentication mechanism
     /// </summary>
     public class ClientCredentialsTokenProvider : OAuthTokenProvider
     {
@@ -55,7 +54,7 @@ namespace Flurl.Http.Authentication
             { body["client_secret"] = _clientSecret; }
 
             var rawResponse = await _fc.Request("connect", "token")
-                                        .WithHeader("accept","application/json")
+                                        .WithHeader("accept", "application/json")
                                         .AllowAnyHttpStatus()
                                         .PostUrlEncodedAsync(body);
 
@@ -73,9 +72,6 @@ namespace Flurl.Http.Authentication
                 {
                     var response = await rawResponse.GetJsonAsync<JsonNode>();
                     errorMessage = response["error"].GetValue<string>();
-
-                    if (errorMessage == "invalid_scope")
-                    { errorMessage = $"{_clientId} is not allowed to utilize scope {scope}, or {scope} is not a valid scope. Verify the allowed scopes for {_clientId} and try again."; }
                 }
                 catch (Exception)
                 {

--- a/src/Flurl.Http/Authentication/ExpirableToken.cs
+++ b/src/Flurl.Http/Authentication/ExpirableToken.cs
@@ -1,0 +1,31 @@
+﻿using System;
+
+namespace Flurl.Http.Authentication
+{
+    /// <summary>
+    /// An expirable token used in token-based authentication
+    /// </summary>
+    public sealed class ExpirableToken
+    {
+        /// <summary>
+        /// Gets and sets the token value
+        /// </summary>
+        public string Value { get; }
+
+        /// <summary>
+        /// Gets and sets the expiration date of the token
+        /// </summary>
+        public DateTimeOffset Expiration { get; }
+
+        /// <summary>
+        /// Instantiates a new ExpirableToken, setting value and expiration
+        /// </summary>
+        /// <param name="value">The value of this token</param>
+        /// <param name="expiration">The date and time that this token expires</param>
+        public ExpirableToken(string value, DateTimeOffset expiration)
+        {
+            Value = value;
+            Expiration = expiration;
+        }
+    }
+}

--- a/src/Flurl.Http/Authentication/ExpirableToken.cs
+++ b/src/Flurl.Http/Authentication/ExpirableToken.cs
@@ -1,10 +1,12 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Flurl.Http.Authentication
 {
-    /// <summary>
-    /// An expirable token used in token-based authentication
-    /// </summary>
+	/// <summary>
+	/// An expirable token used in token-based authentication
+	/// </summary>
+	[ExcludeFromCodeCoverage]
     public sealed class ExpirableToken
     {
         /// <summary>

--- a/src/Flurl.Http/Authentication/IOAuthTokenProvider.cs
+++ b/src/Flurl.Http/Authentication/IOAuthTokenProvider.cs
@@ -1,0 +1,18 @@
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+
+namespace Flurl.Http.Authentication
+{
+    /// <summary>
+    /// Provides the authentication header
+    /// </summary>
+    public interface IOAuthTokenProvider
+    {
+        /// <summary>
+        /// Gets the authentication header for a specified scope.
+        /// </summary>
+        /// <param name="scope">The desired scope</param>
+        /// <returns></returns>
+        Task<AuthenticationHeaderValue> GetAuthenticationHeader(string scope);
+    }
+}

--- a/src/Flurl.Http/Authentication/IOAuthTokenProvider.cs
+++ b/src/Flurl.Http/Authentication/IOAuthTokenProvider.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
 
@@ -9,10 +10,10 @@ namespace Flurl.Http.Authentication
     public interface IOAuthTokenProvider
     {
         /// <summary>
-        /// Gets the authentication header for a specified scope.
+        /// Gets the authentication header for a specified set of scopes.
         /// </summary>
-        /// <param name="scope">The desired scope</param>
+        /// <param name="scopes">The desired set of scopes</param>
         /// <returns></returns>
-        Task<AuthenticationHeaderValue> GetAuthenticationHeader(string scope);
+        Task<AuthenticationHeaderValue> GetAuthenticationHeader(ISet<string> scopes);
     }
 }

--- a/src/Flurl.Http/Authentication/OAuthTokenProvider.cs
+++ b/src/Flurl.Http/Authentication/OAuthTokenProvider.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 using System.Net.Http.Headers;
 using System.Threading;
@@ -56,7 +56,7 @@ namespace Flurl.Http.Authentication
             {
                 return new CacheEntry
                 {
-                    Token = new ExpirableToken("", now - TimeSpan.FromMinutes(1))
+                    Token = new ExpirableToken("", now)
                 };
             });
 
@@ -72,7 +72,12 @@ namespace Flurl.Http.Authentication
                     if (tokenIsValid == false)
                     {
                         var generatedToken = await GetToken(scope);
-                        entry.Token = new ExpirableToken(generatedToken.Value, generatedToken.Expiration - _earlyExpiration);
+
+                        //if we're configured to expire tokens early, adjust the expiration time
+                        if (_earlyExpiration > TimeSpan.Zero)
+                        { generatedToken = new ExpirableToken(generatedToken.Value, generatedToken.Expiration - _earlyExpiration); }
+
+                        entry.Token = generatedToken;
                         entry.AuthHeader = new AuthenticationHeaderValue(_scheme, entry.Token.Value);
                     }
                 }

--- a/src/Flurl.Http/Authentication/OAuthTokenProvider.cs
+++ b/src/Flurl.Http/Authentication/OAuthTokenProvider.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Concurrent;
 using System.Net.Http.Headers;
 using System.Threading;
@@ -6,10 +6,10 @@ using System.Threading.Tasks;
 
 namespace Flurl.Http.Authentication
 {
-    /// <summary>
-    /// The base class for OAuth token providers
-    /// </summary>
-    public abstract class OAuthTokenProvider : IOAuthTokenProvider
+	/// <summary>
+	/// The base class for OAuth token providers
+	/// </summary>
+	public abstract class OAuthTokenProvider : IOAuthTokenProvider
     {
         private class CacheEntry
         {

--- a/src/Flurl.Http/Authentication/OAuthTokenProvider.cs
+++ b/src/Flurl.Http/Authentication/OAuthTokenProvider.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Net.Http.Headers;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Flurl.Http.Authentication
+{
+    /// <summary>
+    /// The base class for OAuth token providers
+    /// </summary>
+    public abstract class OAuthTokenProvider : IOAuthTokenProvider
+    {
+        private class CacheEntry
+        {
+            public SemaphoreSlim Semaphore { get; }
+            public ExpirableToken Token { get; set; }
+            public AuthenticationHeaderValue AuthHeader { get; set; }
+
+            public CacheEntry()
+            {
+                Semaphore = new SemaphoreSlim(1, 1);
+            }
+        }
+
+        private readonly ConcurrentDictionary<string, CacheEntry> _tokens;
+        private readonly TimeSpan _earlyExpiration;
+        private readonly string _scheme;
+
+
+        /// <summary>
+        /// Instantiates a new OAuthTokenProvider
+        /// </summary>
+        /// <param name="earlyExpiration">The amount of time that defines how much earlier a entry should be considered expired relative to its actual expiration</param>
+        /// <param name="authenticationScheme">The authentication scheme this provider will provide in the resolved authentication header. Usually "Bearer" or "OAuth"</param>
+        protected OAuthTokenProvider(
+                                    TimeSpan? earlyExpiration = null,
+                                    string authenticationScheme = "Bearer")
+        {
+            _tokens = new ConcurrentDictionary<string, CacheEntry>();
+            _earlyExpiration = earlyExpiration ?? TimeSpan.Zero;
+            _scheme = authenticationScheme;
+        }
+
+        /// <summary>
+        /// Gets the OAuth authentication header for the specified scope
+        /// </summary>
+        /// <param name="scope">The desired scope</param>
+        /// <returns></returns>
+        public async Task<AuthenticationHeaderValue> GetAuthenticationHeader(string scope)
+        {
+            var now = DateTimeOffset.Now;
+
+            //if the scope is not in the cache, add it as an expired entry so we force a refresh
+            var entry = _tokens.GetOrAdd(scope, s =>
+            {
+                return new CacheEntry
+                {
+                    Token = new ExpirableToken("", now - TimeSpan.FromMinutes(1))
+                };
+            });
+
+            var tokenIsValid = (entry.AuthHeader != null) && (now < entry.Token.Expiration);
+
+            if (tokenIsValid == false)
+            {
+                await entry.Semaphore.WaitAsync();
+                try
+                {
+                    tokenIsValid = (entry.AuthHeader != null) && (now < entry.Token.Expiration);
+
+                    if (tokenIsValid == false)
+                    {
+                        var generatedToken = await GetToken(scope);
+                        entry.Token = new ExpirableToken(generatedToken.Value, generatedToken.Expiration - _earlyExpiration);
+                        entry.AuthHeader = new AuthenticationHeaderValue(_scheme, entry.Token.Value);
+                    }
+                }
+                finally
+                {
+                    entry.Semaphore.Release();
+                }
+            }
+
+            return entry.AuthHeader;
+        }
+
+        /// <summary>
+        /// Retrieves the OAuth token for the specified scope
+        /// </summary>
+        /// <returns>The refreshed OAuth token</returns>
+        protected abstract Task<ExpirableToken> GetToken(string scope);
+    }
+}

--- a/src/Flurl.Http/Configuration/FlurlHttpSettings.cs
+++ b/src/Flurl.Http/Configuration/FlurlHttpSettings.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
+using Flurl.Http.Authentication;
 using Flurl.Http.Testing;
 
 namespace Flurl.Http.Configuration
@@ -82,6 +83,24 @@ namespace Flurl.Http.Configuration
 			get => Get<ISerializer>();
 			set => Set(value);
 		}
+
+		/// <summary>
+        /// Gets or sets the OAuth token provider
+        /// </summary>
+        public IOAuthTokenProvider OAuthTokenProvider
+        {
+            get => Get<IOAuthTokenProvider>();
+            set => Set(value);
+        }
+
+        /// <summary>
+        /// Gets or sets the OAuth scope to request from <see cref="OAuthTokenProvider"/>
+        /// </summary>
+        public string OAuthTokenScope
+        {
+            get => Get<string>();
+            set => Set(value);
+        }
 
 		/// <summary>
 		/// Gets object whose properties describe how Flurl.Http should handle redirect (3xx) responses.

--- a/src/Flurl.Http/Configuration/FlurlHttpSettings.cs
+++ b/src/Flurl.Http/Configuration/FlurlHttpSettings.cs
@@ -96,9 +96,9 @@ namespace Flurl.Http.Configuration
         /// <summary>
         /// Gets or sets the OAuth scope to request from <see cref="OAuthTokenProvider"/>
         /// </summary>
-        public string OAuthTokenScope
+        public ISet<string> OAuthTokenScopes
         {
-            get => Get<string>();
+            get => Get<ISet<string>>();
             set => Set(value);
         }
 

--- a/src/Flurl.Http/FlurlClient.cs
+++ b/src/Flurl.Http/FlurlClient.cs
@@ -160,14 +160,16 @@ namespace Flurl.Http
 
 			//if the settings and handlers didn't set the authorization header,
             //resolve it with the configured provider
-            if (reqMsg.Headers.Authorization == null &&
+            if (request.Headers.TryGetFirst("Authorization", out var authValue) == false &&
+				string.IsNullOrWhiteSpace(authValue) &&
                 settings.OAuthTokenProvider != null)
             {
                 var scope = string.IsNullOrWhiteSpace(settings.OAuthTokenScope) ? string.Empty : settings.OAuthTokenScope;
-                reqMsg.Headers.Authorization = await settings.OAuthTokenProvider.GetAuthenticationHeader(scope);
+                var authHeader = await settings.OAuthTokenProvider.GetAuthenticationHeader(scope);
+                request.Headers.Add("Authorization", authHeader.ToString());
             }
 
-			SyncHeaders(request, reqMsg);
+            SyncHeaders(request, reqMsg);
 
 			call.StartedUtc = DateTime.UtcNow;
 			var ct = GetCancellationTokenWithTimeout(cancellationToken, settings.Timeout, out var cts);

--- a/src/Flurl.Http/FlurlClient.cs
+++ b/src/Flurl.Http/FlurlClient.cs
@@ -157,16 +157,17 @@ namespace Flurl.Http
 
 			// in case URL or headers were modified in the handler above
 			reqMsg.RequestUri = request.Url.ToUri();
-			SyncHeaders(request, reqMsg);
 
 			//if the settings and handlers didn't set the authorization header,
             //resolve it with the configured provider
-            if (call.HttpRequestMessage.Headers.Authorization == null &&
+            if (reqMsg.Headers.Authorization == null &&
                 settings.OAuthTokenProvider != null)
             {
                 var scope = string.IsNullOrWhiteSpace(settings.OAuthTokenScope) ? string.Empty : settings.OAuthTokenScope;
-                call.HttpRequestMessage.Headers.Authorization = await settings.OAuthTokenProvider.GetAuthenticationHeader(scope);
+                reqMsg.Headers.Authorization = await settings.OAuthTokenProvider.GetAuthenticationHeader(scope);
             }
+
+			SyncHeaders(request, reqMsg);
 
 			call.StartedUtc = DateTime.UtcNow;
 			var ct = GetCancellationTokenWithTimeout(cancellationToken, settings.Timeout, out var cts);

--- a/src/Flurl.Http/FlurlClient.cs
+++ b/src/Flurl.Http/FlurlClient.cs
@@ -159,6 +159,15 @@ namespace Flurl.Http
 			reqMsg.RequestUri = request.Url.ToUri();
 			SyncHeaders(request, reqMsg);
 
+			//if the settings and handlers didn't set the authorization header,
+            //resolve it with the configured provider
+            if (call.HttpRequestMessage.Headers.Authorization == null &&
+                settings.OAuthTokenProvider != null)
+            {
+                var scope = string.IsNullOrWhiteSpace(settings.OAuthTokenScope) ? string.Empty : settings.OAuthTokenScope;
+                call.HttpRequestMessage.Headers.Authorization = await settings.OAuthTokenProvider.GetAuthenticationHeader(scope);
+            }
+
 			call.StartedUtc = DateTime.UtcNow;
 			var ct = GetCancellationTokenWithTimeout(cancellationToken, settings.Timeout, out var cts);
 

--- a/src/Flurl.Http/FlurlClient.cs
+++ b/src/Flurl.Http/FlurlClient.cs
@@ -164,8 +164,7 @@ namespace Flurl.Http
 				string.IsNullOrWhiteSpace(authValue) &&
                 settings.OAuthTokenProvider != null)
             {
-                var scope = string.IsNullOrWhiteSpace(settings.OAuthTokenScope) ? string.Empty : settings.OAuthTokenScope;
-                var authHeader = await settings.OAuthTokenProvider.GetAuthenticationHeader(scope);
+                var authHeader = await settings.OAuthTokenProvider.GetAuthenticationHeader(settings.OAuthTokenScopes);
                 request.Headers.Add("Authorization", authHeader.ToString());
             }
 

--- a/src/Flurl.Http/GeneratedExtensions.cs
+++ b/src/Flurl.Http/GeneratedExtensions.cs
@@ -5,6 +5,7 @@ using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using Flurl.Http.Authentication;
 using Flurl.Http.Configuration;
 using Flurl.Http.Content;
 
@@ -732,6 +733,16 @@ namespace Flurl.Http
 		}
 		
 		/// <summary>
+		/// Creates a new FlurlRequest and configures it to request an OAuth bearer token of the specified scope from the OAuth token provider
+		/// </summary>
+		/// <param name="url">This Flurl.Url.</param>
+		/// <param name="scope">The scope of the token</param>
+		/// <returns>A new IFlurlRequest.</returns>
+		public static IFlurlRequest WithOAuthScope(this Url url, string scope) {
+			return new FlurlRequest(url).WithOAuthScope(scope);
+		}
+		
+		/// <summary>
 		/// Creates a new FlurlRequest and adds a new BeforeCall event handler.
 		/// </summary>
 		/// <param name="url">This Flurl.Url.</param>
@@ -1261,6 +1272,16 @@ namespace Flurl.Http
 		}
 		
 		/// <summary>
+		/// Creates a new FlurlRequest and configures it to request an OAuth bearer token of the specified scope from the OAuth token provider
+		/// </summary>
+		/// <param name="url">This URL.</param>
+		/// <param name="scope">The scope of the token</param>
+		/// <returns>A new IFlurlRequest.</returns>
+		public static IFlurlRequest WithOAuthScope(this string url, string scope) {
+			return new FlurlRequest(url).WithOAuthScope(scope);
+		}
+		
+		/// <summary>
 		/// Creates a new FlurlRequest and adds a new BeforeCall event handler.
 		/// </summary>
 		/// <param name="url">This URL.</param>
@@ -1787,6 +1808,16 @@ namespace Flurl.Http
 		/// <returns>A new IFlurlRequest.</returns>
 		public static IFlurlRequest WithOAuthTokenProvider(this Uri uri, IOAuthTokenProvider tokenProvider) {
 			return new FlurlRequest(uri).WithOAuthTokenProvider(tokenProvider);
+		}
+		
+		/// <summary>
+		/// Creates a new FlurlRequest and configures it to request an OAuth bearer token of the specified scope from the OAuth token provider
+		/// </summary>
+		/// <param name="uri">This System.Uri.</param>
+		/// <param name="scope">The scope of the token</param>
+		/// <returns>A new IFlurlRequest.</returns>
+		public static IFlurlRequest WithOAuthScope(this Uri uri, string scope) {
+			return new FlurlRequest(uri).WithOAuthScope(scope);
 		}
 		
 		/// <summary>

--- a/src/Flurl.Http/GeneratedExtensions.cs
+++ b/src/Flurl.Http/GeneratedExtensions.cs
@@ -738,8 +738,8 @@ namespace Flurl.Http
 		/// <param name="url">This Flurl.Url.</param>
 		/// <param name="scope">The scope of the token</param>
 		/// <returns>A new IFlurlRequest.</returns>
-		public static IFlurlRequest WithOAuthScope(this Url url, string scope) {
-			return new FlurlRequest(url).WithOAuthScope(scope);
+		public static IFlurlRequest WithOAuthTokenFromProvider(this Url url, string scope) {
+			return new FlurlRequest(url).WithOAuthTokenFromProvider(scope);
 		}
 		
 		/// <summary>

--- a/src/Flurl.Http/GeneratedExtensions.cs
+++ b/src/Flurl.Http/GeneratedExtensions.cs
@@ -1816,8 +1816,8 @@ namespace Flurl.Http
 		/// <param name="uri">This System.Uri.</param>
 		/// <param name="scope">The scope of the token</param>
 		/// <returns>A new IFlurlRequest.</returns>
-		public static IFlurlRequest WithOAuthScope(this Uri uri, string scope) {
-			return new FlurlRequest(uri).WithOAuthScope(scope);
+		public static IFlurlRequest WithOAuthTokenFromProvider(this Uri uri, string scope) {
+			return new FlurlRequest(uri).WithOAuthTokenFromProvider(scope);
 		}
 		
 		/// <summary>

--- a/src/Flurl.Http/GeneratedExtensions.cs
+++ b/src/Flurl.Http/GeneratedExtensions.cs
@@ -1277,8 +1277,8 @@ namespace Flurl.Http
 		/// <param name="url">This URL.</param>
 		/// <param name="scope">The scope of the token</param>
 		/// <returns>A new IFlurlRequest.</returns>
-		public static IFlurlRequest WithOAuthScope(this string url, string scope) {
-			return new FlurlRequest(url).WithOAuthScope(scope);
+		public static IFlurlRequest WithOAuthTokenFromProvider(this string url, string scope) {
+			return new FlurlRequest(url).WithOAuthTokenFromProvider(scope);
 		}
 		
 		/// <summary>

--- a/src/Flurl.Http/GeneratedExtensions.cs
+++ b/src/Flurl.Http/GeneratedExtensions.cs
@@ -722,6 +722,16 @@ namespace Flurl.Http
 		}
 		
 		/// <summary>
+		/// Creates a new FlurlRequest and configures it to use the supplied OAuth token provider for the request's authentication header
+		/// </summary>
+		/// <param name="url">This Flurl.Url.</param>
+		/// <param name="tokenProvider">the token provider</param>
+		/// <returns>A new IFlurlRequest.</returns>
+		public static IFlurlRequest WithOAuthTokenProvider(this Url url, IOAuthTokenProvider tokenProvider) {
+			return new FlurlRequest(url).WithOAuthTokenProvider(tokenProvider);
+		}
+		
+		/// <summary>
 		/// Creates a new FlurlRequest and adds a new BeforeCall event handler.
 		/// </summary>
 		/// <param name="url">This Flurl.Url.</param>
@@ -1241,6 +1251,16 @@ namespace Flurl.Http
 		}
 		
 		/// <summary>
+		/// Creates a new FlurlRequest and configures it to use the supplied OAuth token provider for the request's authentication header
+		/// </summary>
+		/// <param name="url">This URL.</param>
+		/// <param name="tokenProvider">the token provider</param>
+		/// <returns>A new IFlurlRequest.</returns>
+		public static IFlurlRequest WithOAuthTokenProvider(this string url, IOAuthTokenProvider tokenProvider) {
+			return new FlurlRequest(url).WithOAuthTokenProvider(tokenProvider);
+		}
+		
+		/// <summary>
 		/// Creates a new FlurlRequest and adds a new BeforeCall event handler.
 		/// </summary>
 		/// <param name="url">This URL.</param>
@@ -1757,6 +1777,16 @@ namespace Flurl.Http
 		/// <returns>A new IFlurlRequest.</returns>
 		public static IFlurlRequest WithAutoRedirect(this Uri uri, bool enabled) {
 			return new FlurlRequest(uri).WithAutoRedirect(enabled);
+		}
+		
+		/// <summary>
+		/// Creates a new FlurlRequest and configures it to use the supplied OAuth token provider for the request's authentication header
+		/// </summary>
+		/// <param name="uri">This System.Uri.</param>
+		/// <param name="tokenProvider">the token provider</param>
+		/// <returns>A new IFlurlRequest.</returns>
+		public static IFlurlRequest WithOAuthTokenProvider(this Uri uri, IOAuthTokenProvider tokenProvider) {
+			return new FlurlRequest(uri).WithOAuthTokenProvider(tokenProvider);
 		}
 		
 		/// <summary>

--- a/src/Flurl.Http/GeneratedExtensions.cs
+++ b/src/Flurl.Http/GeneratedExtensions.cs
@@ -733,13 +733,13 @@ namespace Flurl.Http
 		}
 		
 		/// <summary>
-		/// Creates a new FlurlRequest and configures it to request an OAuth bearer token of the specified scope from the OAuth token provider
+		/// Creates a new FlurlRequest and configures it to request an OAuth bearer token of the specified scope(s) from the OAuth token provider
 		/// </summary>
 		/// <param name="url">This Flurl.Url.</param>
-		/// <param name="scope">The scope of the token</param>
+		/// <param name="scopes">The scope(s) of the token</param>
 		/// <returns>A new IFlurlRequest.</returns>
-		public static IFlurlRequest WithOAuthTokenFromProvider(this Url url, string scope) {
-			return new FlurlRequest(url).WithOAuthTokenFromProvider(scope);
+		public static IFlurlRequest WithOAuthTokenFromProvider(this Url url, params string[] scopes) {
+			return new FlurlRequest(url).WithOAuthTokenFromProvider(scopes);
 		}
 		
 		/// <summary>
@@ -1272,13 +1272,13 @@ namespace Flurl.Http
 		}
 		
 		/// <summary>
-		/// Creates a new FlurlRequest and configures it to request an OAuth bearer token of the specified scope from the OAuth token provider
+		/// Creates a new FlurlRequest and configures it to request an OAuth bearer token of the specified scope(s) from the OAuth token provider
 		/// </summary>
 		/// <param name="url">This URL.</param>
-		/// <param name="scope">The scope of the token</param>
+		/// <param name="scopes">The scope(s) of the token</param>
 		/// <returns>A new IFlurlRequest.</returns>
-		public static IFlurlRequest WithOAuthTokenFromProvider(this string url, string scope) {
-			return new FlurlRequest(url).WithOAuthTokenFromProvider(scope);
+		public static IFlurlRequest WithOAuthTokenFromProvider(this string url, params string[] scopes) {
+			return new FlurlRequest(url).WithOAuthTokenFromProvider(scopes);
 		}
 		
 		/// <summary>
@@ -1811,13 +1811,13 @@ namespace Flurl.Http
 		}
 		
 		/// <summary>
-		/// Creates a new FlurlRequest and configures it to request an OAuth bearer token of the specified scope from the OAuth token provider
+		/// Creates a new FlurlRequest and configures it to request an OAuth bearer token of the specified scope(s) from the OAuth token provider
 		/// </summary>
 		/// <param name="uri">This System.Uri.</param>
-		/// <param name="scope">The scope of the token</param>
+		/// <param name="scopes">The scope(s) of the token</param>
 		/// <returns>A new IFlurlRequest.</returns>
-		public static IFlurlRequest WithOAuthTokenFromProvider(this Uri uri, string scope) {
-			return new FlurlRequest(uri).WithOAuthTokenFromProvider(scope);
+		public static IFlurlRequest WithOAuthTokenFromProvider(this Uri uri, params string[] scopes) {
+			return new FlurlRequest(uri).WithOAuthTokenFromProvider(scopes);
 		}
 		
 		/// <summary>

--- a/src/Flurl.Http/ISettingsContainer.cs
+++ b/src/Flurl.Http/ISettingsContainer.cs
@@ -114,5 +114,16 @@ namespace Flurl.Http
 			obj.Settings.OAuthTokenProvider = tokenProvider;
 			return obj;
 		}
+
+		/// <summary>
+		/// Configures the OAuth scope to obtain from the configured OAuthTokenProvider
+		/// </summary>
+		/// <param name="obj">Object containing settings.</param>
+		/// <param name="scope">The scope of the token</param>
+		/// <returns></returns>
+		public static T WithOAuthScope<T>(this T obj, string scope) where T : ISettingsContainer {
+			obj.Settings.OAuthTokenScope = scope;
+			return obj;
+		}
 	}
 }

--- a/src/Flurl.Http/ISettingsContainer.cs
+++ b/src/Flurl.Http/ISettingsContainer.cs
@@ -121,7 +121,7 @@ namespace Flurl.Http
 		/// <param name="obj">Object containing settings.</param>
 		/// <param name="scope">The scope of the token</param>
 		/// <returns></returns>
-		public static T WithOAuthScope<T>(this T obj, string scope) where T : ISettingsContainer {
+		public static T WithOAuthTokenFromProvider<T>(this T obj, string scope) where T : ISettingsContainer {
 			obj.Settings.OAuthTokenScope = scope;
 			return obj;
 		}

--- a/src/Flurl.Http/ISettingsContainer.cs
+++ b/src/Flurl.Http/ISettingsContainer.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Net;
+using Flurl.Http.Authentication;
 using Flurl.Http.Configuration;
 
 namespace Flurl.Http
@@ -100,6 +101,17 @@ namespace Flurl.Http
 		/// <returns>This settings container.</returns>
 		public static T WithAutoRedirect<T>(this T obj, bool enabled) where T : ISettingsContainer {
 			obj.Settings.Redirects.Enabled = enabled;
+			return obj;
+		}
+
+		/// <summary>
+		/// Configures the OAuth token provider which authenticates the request
+		/// </summary>
+		/// <param name="obj">Object containing settings.</param>
+		/// <param name="tokenProvider">The token provider</param>
+		/// <returns>this settings container.</returns>
+		public static T WithOAuthTokenProvider<T>(this T obj, IOAuthTokenProvider tokenProvider) where T : ISettingsContainer {
+			obj.Settings.OAuthTokenProvider = tokenProvider;
 			return obj;
 		}
 	}

--- a/src/Flurl.Http/ISettingsContainer.cs
+++ b/src/Flurl.Http/ISettingsContainer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using Flurl.Http.Authentication;
@@ -116,13 +117,14 @@ namespace Flurl.Http
 		}
 
 		/// <summary>
-		/// Configures the OAuth scope to obtain from the configured OAuthTokenProvider
+		/// Configures the OAuth scope(s) to obtain from the configured OAuthTokenProvider
 		/// </summary>
 		/// <param name="obj">Object containing settings.</param>
-		/// <param name="scope">The scope of the token</param>
+		/// <param name="scopes">The scope(s) of the token</param>
 		/// <returns></returns>
-		public static T WithOAuthTokenFromProvider<T>(this T obj, string scope) where T : ISettingsContainer {
-			obj.Settings.OAuthTokenScope = scope;
+		public static T WithOAuthTokenFromProvider<T>(this T obj, params string[] scopes) where T : ISettingsContainer {
+			var distinctScopes = new HashSet<string>(scopes ?? Array.Empty<string>());
+			obj.Settings.OAuthTokenScopes = distinctScopes;
 			return obj;
 		}
 	}

--- a/test/Flurl.Test/Http/Authentication/ClientCredentialsTokenProviderTests.cs
+++ b/test/Flurl.Test/Http/Authentication/ClientCredentialsTokenProviderTests.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace Flurl.Test.Http.Authentication
 {
-    [TestFixture]
+	[TestFixture]
     public class ClientCredentialsTokenProviderTests : HttpTestFixtureBase
     {
         [TestCase("secret")]
@@ -28,12 +28,12 @@ namespace Flurl.Test.Http.Authentication
 
             var provider = new ClientCredentialsTokenProvider("unitTestClient", clientSecret, cli);
 
-            var authHeader = await provider.GetAuthenticationHeader("scope");
+            var authHeader = await provider.GetAuthenticationHeader("unitTestScope");
 
             HttpTest.ShouldHaveCalled("https://flurl.dev/connect/token")
                     .WithVerb(HttpMethod.Post)
                     .WithContentType("application/x-www-form-urlencoded")
-                    .WithRequestBody($"client_id=clientId&scope=scope&grant_type=client_credentials{(string.IsNullOrWhiteSpace(clientSecret) ? "" : $"&client_secret={clientSecret}")}")
+                    .WithRequestBody($"client_id=unitTestClient&scope=unitTestScope&grant_type=client_credentials{(string.IsNullOrWhiteSpace(clientSecret) ? "" : $"&client_secret={clientSecret}")}")
                     .WithHeader("accept", "application/json")
                     .Times(1);
         }

--- a/test/Flurl.Test/Http/Authentication/ClientCredentialsTokenProviderTests.cs
+++ b/test/Flurl.Test/Http/Authentication/ClientCredentialsTokenProviderTests.cs
@@ -1,0 +1,104 @@
+﻿using Flurl.Http;
+using Flurl.Http.Authentication;
+using Flurl.Http.Testing;
+using NUnit.Framework;
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace Flurl.Test.Http.Authentication
+{
+    [TestFixture]
+    public class ClientCredentialsTokenProviderTests : HttpTestFixtureBase
+    {
+        [TestCase("secret")]
+        [TestCase("")]
+        [TestCase(null)]
+        public async Task GetAuthenticationHeader_OnlyPassesClientSecretIfSet(string clientSecret)
+        {
+            var body = new
+            {
+                access_token = "UnitTestAccessToken",
+                expires_in = 3600
+            };
+
+            HttpTest.RespondWithJson(body);
+
+            var cli = new FlurlClient("https://flurl.dev");
+
+            var provider = new ClientCredentialsTokenProvider("unitTestClient", clientSecret, cli);
+
+            var authHeader = await provider.GetAuthenticationHeader("scope");
+
+            HttpTest.ShouldHaveCalled("https://flurl.dev/connect/token")
+                    .WithVerb(HttpMethod.Post)
+                    .WithContentType("application/x-www-form-urlencoded")
+                    .WithRequestBody($"client_id=clientId&scope=scope&grant_type=client_credentials{(string.IsNullOrWhiteSpace(clientSecret) ? "" : $"&client_secret={clientSecret}")}")
+                    .WithHeader("accept", "application/json")
+                    .Times(1);
+        }
+
+        [Test]
+        public async Task GetAuthenticationHeader_ReturnsTokenForSuccessfulResponse()
+        {
+            var body = new
+            {
+                access_token = "UnitTestAccessToken",
+                expires_in = 3600
+            };
+
+            HttpTest.RespondWithJson(body);
+
+            var cli = new FlurlClient("https://flurl.dev");
+
+            var provider = new ClientCredentialsTokenProvider("unitTestClient", "secret", cli);
+
+            var authHeader = await provider.GetAuthenticationHeader("scope");
+
+            Assert.AreEqual("UnitTestAccessToken", authHeader.Parameter);
+        }
+
+        [Test]
+        public void GetAuthenticationHeader_ThrowsUnauthorizedForErrorMessageResponse()
+        {
+            var body = new
+            {
+                error = "invalid_scope",
+            };
+
+            HttpTest.RespondWithJson(body, 400);
+
+            var cli = new FlurlClient("https://flurl.dev");
+
+            var provider = new ClientCredentialsTokenProvider("unitTestClient", "secret", cli);
+
+            Assert.ThrowsAsync<UnauthorizedAccessException>(() => provider.GetAuthenticationHeader("testScope"));
+        }
+
+        [Test]
+        public void GetAuthenticationHeader_ThrowsUnauthorizedForGarbageResponse()
+        {
+            HttpTest.RespondWith("garbage", 400);
+
+            var cli = new FlurlClient("https://flurl.dev");
+
+            var provider = new ClientCredentialsTokenProvider("unitTestClient", "secret", cli);
+
+            var expectedMessage = $"unitTestClient is not allowed to utilize scope testScope, or testScope is not a valid scope. Verify the allowed scopes for unitTestClient and try again.";
+            Assert.ThrowsAsync<UnauthorizedAccessException>(() => provider.GetAuthenticationHeader("testScope"), expectedMessage);
+        }
+
+        [Test]
+        public void GetAuthenticationHeader_ThrowsUnauthorizedForNon400Response()
+        {
+            HttpTest.RespondWith("garbage", 500);
+
+            var cli = new FlurlClient("https://flurl.dev");
+
+            var provider = new ClientCredentialsTokenProvider("unitTestClient", "secret", cli);
+
+            var expectedMessage = "Unable to acquire OAuth token";
+            Assert.ThrowsAsync<UnauthorizedAccessException>(() => provider.GetAuthenticationHeader("testScope"), expectedMessage);
+        }
+    }
+}

--- a/test/Flurl.Test/Http/Authentication/OAuthTokenProviderTests.cs
+++ b/test/Flurl.Test/Http/Authentication/OAuthTokenProviderTests.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 
 namespace Flurl.Test.Http.Authentication
 {
-    internal class UnitTestTokenProvider : OAuthTokenProvider
+	internal class UnitTestTokenProvider : OAuthTokenProvider
     {
         private int _generationCount = 0;
         public UnitTestTokenProvider() : base()

--- a/test/Flurl.Test/Http/Authentication/OAuthTokenProviderTests.cs
+++ b/test/Flurl.Test/Http/Authentication/OAuthTokenProviderTests.cs
@@ -5,22 +5,22 @@ using System.Threading.Tasks;
 
 namespace Flurl.Test.Http.Authentication
 {
+    internal class UnitTestTokenProvider : OAuthTokenProvider
+    {
+        private int _generationCount = 0;
+        public UnitTestTokenProvider() : base()
+        {
+        }
+
+        protected override Task<ExpirableToken> GetToken(string scope)
+        {
+            return Task.FromResult(new ExpirableToken((++_generationCount).ToString(), DateTimeOffset.Now.AddSeconds(1)));
+        }
+    }
+
     [TestFixture]
     public class OAuthTokenProviderTests
     {
-        internal class UnitTestTokenProvider : OAuthTokenProvider
-        {
-            private int _generationCount = 0;
-            public UnitTestTokenProvider() : base()
-            {
-            }
-
-            protected override Task<ExpirableToken> GetToken(string scope)
-            {
-                return Task.FromResult(new ExpirableToken((++_generationCount).ToString(), DateTimeOffset.Now.AddSeconds(1)));
-            }
-        }
-
         [Test]
         public async Task GetAuthenticationHeader_ReusesValidTokens()
         {

--- a/test/Flurl.Test/Http/Authentication/OAuthTokenProviderTests.cs
+++ b/test/Flurl.Test/Http/Authentication/OAuthTokenProviderTests.cs
@@ -1,0 +1,40 @@
+﻿using Flurl.Http.Authentication;
+using NUnit.Framework;
+using System;
+using System.Threading.Tasks;
+
+namespace Flurl.Test.Http.Authentication
+{
+    [TestFixture]
+    public class OAuthTokenProviderTests
+    {
+        internal class UnitTestTokenProvider : OAuthTokenProvider
+        {
+            private int _generationCount = 0;
+            public UnitTestTokenProvider() : base()
+            {
+            }
+
+            protected override Task<ExpirableToken> GetToken(string scope)
+            {
+                return Task.FromResult(new ExpirableToken((++_generationCount).ToString(), DateTimeOffset.Now.AddSeconds(1)));
+            }
+        }
+
+        [Test]
+        public async Task GetAuthenticationHeader_ReusesValidTokens()
+        {
+            var provider = new UnitTestTokenProvider();
+
+            var header1 = await provider.GetAuthenticationHeader("scope");
+            var header2 = await provider.GetAuthenticationHeader("scope");
+
+            await Task.Delay(TimeSpan.FromSeconds(1));
+
+            var header3 = await provider.GetAuthenticationHeader("scope");
+
+            Assert.AreEqual(header1.Parameter, header2.Parameter);
+            Assert.AreNotEqual(header1.Parameter, header3.Parameter);
+        }
+    }
+}

--- a/test/Flurl.Test/Http/Authentication/OAuthTokenProviderTests.cs
+++ b/test/Flurl.Test/Http/Authentication/OAuthTokenProviderTests.cs
@@ -1,6 +1,7 @@
 ﻿using Flurl.Http.Authentication;
 using NUnit.Framework;
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Flurl.Test.Http.Authentication
@@ -12,7 +13,7 @@ namespace Flurl.Test.Http.Authentication
         {
         }
 
-        protected override Task<ExpirableToken> GetToken(string scope)
+        protected override Task<ExpirableToken> GetToken(ISet<string> scopes)
         {
             return Task.FromResult(new ExpirableToken((++_generationCount).ToString(), DateTimeOffset.Now.AddSeconds(1)));
         }
@@ -26,12 +27,14 @@ namespace Flurl.Test.Http.Authentication
         {
             var provider = new UnitTestTokenProvider();
 
-            var header1 = await provider.GetAuthenticationHeader("scope");
-            var header2 = await provider.GetAuthenticationHeader("scope");
+            var scopes = new HashSet<string>(new[] { "scope1" });
+            
+            var header1 = await provider.GetAuthenticationHeader(scopes);
+            var header2 = await provider.GetAuthenticationHeader(scopes);
 
-            await Task.Delay(TimeSpan.FromSeconds(1));
+            await Task.Delay(TimeSpan.FromSeconds(2));
 
-            var header3 = await provider.GetAuthenticationHeader("scope");
+            var header3 = await provider.GetAuthenticationHeader(scopes);
 
             Assert.AreEqual(header1.Parameter, header2.Parameter);
             Assert.AreNotEqual(header1.Parameter, header3.Parameter);

--- a/test/Flurl.Test/Http/SettingsTests.cs
+++ b/test/Flurl.Test/Http/SettingsTests.cs
@@ -167,7 +167,6 @@ namespace Flurl.Test.Http
                 var h = test.CallLog[0].Request.Headers;
                 Assert.True(h.TryGetFirst("authorization", out var authHeaderValue));
                 Assert.AreEqual("Bearer 1", authHeaderValue);
-
             }
             catch (Exception ex)
             {

--- a/test/Flurl.Test/Http/SettingsTests.cs
+++ b/test/Flurl.Test/Http/SettingsTests.cs
@@ -168,7 +168,7 @@ namespace Flurl.Test.Http
                 Assert.True(h.TryGetFirst("authorization", out var authHeaderValue));
                 Assert.AreEqual("Bearer 1", authHeaderValue);
             }
-            catch (Exception ex)
+            catch (Exception)
             {
                 Assert.Fail("Exception should not have been thrown.");
             }

--- a/test/Flurl.Test/Http/SettingsTests.cs
+++ b/test/Flurl.Test/Http/SettingsTests.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Flurl.Http;
 using Flurl.Http.Configuration;
 using Flurl.Http.Testing;
+using Flurl.Test.Http.Authentication;
 using NUnit.Framework;
 
 namespace Flurl.Test.Http
@@ -149,6 +150,30 @@ namespace Flurl.Test.Http
 				Assert.Fail("Exception should not have been thrown.");
 			}
 		}
+
+		[Test]
+        public async Task set_oauthTokenProvider_sets_authenticationHeader_on_request()
+        {
+            using var test = new HttpTest();
+            test.RespondWith("OK", 200);
+
+            try
+            {
+                var c = CreateContainer();
+                c.Settings.OAuthTokenProvider = new UnitTestTokenProvider();
+
+                var result = await GetRequest(c).GetAsync();
+
+                var h = test.CallLog[0].Request.Headers;
+                Assert.True(h.TryGetFirst("authorization", out var authHeaderValue));
+                Assert.AreEqual("Bearer 1", authHeaderValue);
+
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail("Exception should not have been thrown.");
+            }
+        }
 	}
 
 	[TestFixture]


### PR DESCRIPTION
Resolves #678 

Flurl has a way to add bearer tokens to the authentication header via `.WithOAuthBearerToken`, but it's on us, the users of Flurl to retrieve, cache, and renew those tokens.

This pull request adds that functionality by adding an IOAuthTokenProvider and a set of OAuth scopes to the settings. The token provider is responsible for making the call to retrieve the token, but only when the token is expired. The scopes are set separately so that callers can vary their scopes to the section of code/specific requests where appropriate. However, if all requests require the same scope(s), then you can also set it at the same time you set the token provider.

A client credentials provider for identity server is provided. If your token provider has different requirements/payloads/conventions/etc, you can use it as a reference implementation to create your own token provider.

**Usage**:
Register the token provider as a singleton, otherwise the caching mechanism wont work:
``` C#
// ClientID/ClientSecret
services.AddSingleton<IOAuthTokenProvider>(sp =>{
   var clientId = "yourClientId";
   var clientSecret = "yourClientSecret";

   var fc = new FlurlClientBuilder("https://yourIdentityServerBaseAddress.com") 
                        .Build();

   return new ClientCredentialsTokenProvider(clientId, clientSecret, fc);   
}
// OR....
// certificate based authentication
services.AddSingleton<IOAuthTokenProvider(sp =>{
  var clientId = "yourClientId"
  var cert = //retrieve your X509 Certificate

   var fc = new FlurlClientBuilder("https://yourIdentityServerBaseAddress.com") 
                       .ConfigureInnerHandler(handler =>{
                          handler.ClientCertificates.Add(cert);
                        }
                        .Build();

   return new ClientCredentialsTokenProvider(clientId, clientSecret: null, fc);
});
```

When creating a client:

```C#
IFlurlClientCache cache = //instantiate or get from FlurlHttp.Clients

var tokenProvider = serviceProvider.GetRequiredService<IOAuthTokenProvider>();
cache.Add("yourClientName", "https://myapi.com", builder => {
  builder.WithOAuthTokenProvider(tokenProvider);
});
```

When making a request

```C#
  IFlurlClient fc = //however you resolve the flurl client

  fc.Request("your","path")
     .WithOAuthTokenFromProvider(scope: "your:scope")
     .... //complete your request
 ```

